### PR TITLE
Refresh docs for runtime loading and authoring workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 # Diagram Tour
 
-Diagram Tour is an open-source framework for **explainable diagrams**.
+Diagram Tour is an open-source framework for explainable diagrams.
 
-It allows you to create **guided, step-by-step explanations for Mermaid diagrams** using a simple YAML tour definition. Instead of static architecture diagrams, you can provide interactive walkthroughs that highlight components and explain system flows.
+It lets you pair Mermaid diagrams with YAML tour definitions so people can move through a system one step at a time instead of reading a static diagram cold.
 
-## Example
+## Current Capabilities
+
+The repository currently provides:
+
+- Mermaid flowchart parsing with stable node IDs
+- YAML tour parsing and validation
+- recursive discovery of `*.tour.yaml` files from a directory
+- single-file preview for authoring workflows
+- slug-based routing for multiple tours
+- deep links to specific steps through `?step=`
+- step text with `{{node_id}}` label interpolation
+- semantic focus steps, including multi-focus and empty-focus steps
+- a Svelte web player with guided navigation
+- theme persistence across reloads and direct links
+- guided recovery for unknown tour routes
+- smoke coverage for viewport behavior and large-diagram scenarios
+
+## Quick Example
 
 Mermaid diagram:
 
@@ -35,107 +52,111 @@ steps:
       The {{validation_service}} verifies the request before it continues.
 ```
 
-Diagram Tour renders this as a **guided explanation** that highlights nodes and walks the user through the system step by step.
+The player resolves `{{api_gateway}}` to `API Gateway`, highlights the selected focus targets, and lets readers move through the tour step by step.
 
-## Core Concepts
+## Tour Model
 
-### Mermaid Diagram
+Version 1 tour files contain:
 
-Diagram Tour works on Mermaid diagrams.
-
-Nodes must have **stable IDs** so the tour can reference them.
-
-Example:
-
-```mermaid
-api_gateway[API Gateway]
-```
-
-### Tour Definition
-
-A YAML file defines the walkthrough.
+- `version`
+- `title`
+- `diagram`
+- `steps`
 
 Each step contains:
 
-- nodes to focus
-- explanation text
+- `focus`
+- `text`
 
-References inside text use:
+`focus` references Mermaid node IDs. `text` can reference those same IDs with `{{node_id}}`, which resolves to the node label from the diagram.
 
-```text
-{{node_id}}
+An empty focus array is valid:
+
+```yaml
+focus: []
 ```
 
-Example:
+That means the step has no specific node emphasis. The player may use that for a reset, overview, or neutral context moment.
 
-```text
-The {{api_gateway}} forwards the request to {{validation_service}}.
-```
-
-These references resolve automatically to the **Mermaid label**.
+Full contract details live in [docs/tour-spec-v1.md](docs/tour-spec-v1.md).
 
 ## Repository Structure
 
 ```text
 packages/
-  core/        domain model and tour engine
-  parser/      YAML + Mermaid parsing
-  web-player/  UI for running tours
+  core/        shared domain types
+  parser/      YAML + Mermaid loading, parsing, validation, discovery
+  web-player/  Svelte UI for interactive tours
 
 examples/
-  sample tours
+  reference tours and stress fixtures
 
-fixtures/
-  test fixtures
+docs/
+  product, architecture, runtime, and authoring docs
 ```
 
-## Project Goals (v1)
+## Example Tours
 
-- Guided tours for Mermaid flowcharts
-- YAML tour definitions
-- Highlight focused nodes
-- Step-by-step explanation text
-- Simple web player
+The repository ships with a small example library that doubles as product reference material and regression coverage.
 
-## Non-goals (v1)
+| Example | Purpose |
+| --- | --- |
+| `payment-flow` | Baseline guided architecture walkthrough |
+| `refund-flow` | Additional linear product-style flow |
+| `decision-flow` | Branch-heavy Mermaid structure |
+| `incident-response` | Operational walkthrough example |
+| `parallel-onboarding` | Parallel path explanation |
+| `release-pipeline` | Delivery pipeline tour |
+| `support-decision-tree` | Decision-tree style diagram |
+| `viewport-stability` | Empty-focus and viewport stability fixture |
+| `viewport-centering` | Top, bottom, grouped, and neutral focus viewport checks |
+| `huge-system` | Large stress-test tour for dense diagrams and label readability |
 
-- audio narration
-- branching tours
-- multi-diagram tours
-- complex animations
+## Local Development
 
-## How This Repository Is Developed
+Install dependencies:
 
-Diagram Tour is developed in an AI-assisted workflow with **delivery mode** as the default operating model.
+```bash
+bun install
+```
 
-The owner defines product direction and desired capabilities. Codex is expected to carry bounded tasks through design, tests, implementation, refactoring, and final green checks without unnecessary pause points between those steps.
+Start the web player against the default `examples/` directory:
 
-We value:
+```bash
+bun run dev
+```
 
-- contracts first
-- strong guardrails
-- clear tests
-- 100% test coverage
-- separation of responsibilities
-- updated documentation when behavior or contracts change
+Preview a single tour file directly:
 
-## Development
+```bash
+DIAGRAM_TOUR_SOURCE_TARGET=./examples/payment-flow/payment-flow.tour.yaml bun run dev
+```
 
-This project uses:
+PowerShell:
 
-- Bun
-- TypeScript
-- strict lint rules
-- Stylelint for modular CSS guardrails
-- TDD workflow
-- enforced 100% coverage thresholds
+```powershell
+$env:DIAGRAM_TOUR_SOURCE_TARGET = "./examples/payment-flow/payment-flow.tour.yaml"
+bun run dev
+```
 
-Before contributing, read:
+Preview a custom examples directory:
 
-- AGENTS.md
-- ENGINEERING_PLAYBOOK.md
-- REPO_WORK_RULES.md
-- DELIVERY_CHECKLIST.md
+```bash
+DIAGRAM_TOUR_SOURCE_TARGET=./examples bun run dev
+```
+
+PowerShell:
+
+```powershell
+$env:DIAGRAM_TOUR_SOURCE_TARGET = "./examples"
+bun run dev
+```
+
+If you run smoke tests locally for the first time, install Chromium once:
+
+```bash
+bunx playwright install chromium
+```
 
 ## Commands
 
@@ -144,9 +165,48 @@ Before contributing, read:
 - `bun run test`
 - `bun run smoke`
 - `bun run build`
+- `bun run dev`
 
-If you are running smoke tests locally for the first time, install the browser once:
+## CI
 
-```bash
-bunx playwright install chromium
-```
+GitHub Actions currently validates pull requests and `main` with:
+
+- `bun install --frozen-lockfile`
+- `bun run lint`
+- `bun run typecheck`
+- `bun run test`
+- `bunx playwright install --with-deps chromium`
+- `bun run smoke`
+- `bun run build`
+
+That means CI covers static checks, unit coverage, browser smoke coverage, and production buildability.
+
+## Documentation
+
+Start here when working in the repo:
+
+- [AGENTS.md](AGENTS.md)
+- [ENGINEERING_PLAYBOOK.md](ENGINEERING_PLAYBOOK.md)
+- [REPO_WORK_RULES.md](REPO_WORK_RULES.md)
+- [DELIVERY_CHECKLIST.md](DELIVERY_CHECKLIST.md)
+
+Then use the product docs:
+
+- [Tour Specification v1](docs/tour-spec-v1.md)
+- [Architecture Overview](docs/architecture/overview.md)
+- [Runtime Loading](docs/runtime-loading.md)
+- [Authoring Guide](docs/authoring-guide.md)
+- [ADR 0001: Runtime Loading and Focus Semantics](docs/adr/0001-runtime-loading-and-focus-semantics.md)
+
+## Development Expectations
+
+Diagram Tour is developed in an AI-assisted workflow with delivery mode as the default operating model.
+
+The repository expects:
+
+- contracts first
+- strong guardrails
+- clear tests
+- 100% coverage for statements, branches, functions, and lines
+- separation of responsibilities across packages
+- documentation updates when behavior or contracts change

--- a/docs/adr/0001-runtime-loading-and-focus-semantics.md
+++ b/docs/adr/0001-runtime-loading-and-focus-semantics.md
@@ -1,0 +1,42 @@
+# ADR 0001: Runtime Loading and Focus Semantics
+
+## Status
+
+Accepted
+
+## Context
+
+Diagram Tour needs to support two complementary workflows:
+
+- browsing a collection of example or product tours
+- previewing a single tour quickly while authoring
+
+The player also needs to support different visual treatments of focus without baking UI rules into the content contract.
+
+## Decision
+
+The system treats `focus` as semantic intent rather than a hard-coded viewport or styling instruction.
+
+The system also supports two runtime loading modes through a single source-target abstraction:
+
+- directory loading for discoverable tour collections
+- single-file loading for focused author preview
+
+## Consequences
+
+Benefits:
+
+- tour files stay product-oriented instead of UI-config heavy
+- different players can render focus differently without changing the contract
+- authoring and docs-shell workflows share the same parser and resolved model
+- the same application can serve both a curated tour library and a single local draft
+
+Tradeoffs:
+
+- the specification cannot promise a precise visual effect for focus
+- slug generation and collection behavior become part of runtime conventions
+- the web player must translate semantic focus into concrete viewport and highlight behavior
+
+## Notes
+
+This ADR documents current repository behavior. If future versions introduce player-specific focus controls or alternative loading backends, this decision should be revisited.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,10 +1,125 @@
 # Architecture
 
-Diagram Tour is split into a small set of focused packages inside a Bun monorepo.
+Diagram Tour is a Bun monorepo split into a small number of focused packages.
 
-- `core` defines the shared domain model and will grow into the tour engine that coordinates steps, focus targets, and playback state.
-- `parser` reads Mermaid diagram files and tour YAML files, then normalizes and validates them into the core domain types.
-- `web-player` provides the browser UI for loading a tour and running it interactively.
+## Package Responsibilities
 
-Later versions may add optional plugins or integrations for features such as text-to-speech or audio narration, but those are out of scope for the current scaffold.
+- `packages/core` defines the shared domain model used by the rest of the system
+- `packages/parser` loads Mermaid and YAML inputs, validates them, resolves node references, discovers tours, and returns runtime-ready collections
+- `packages/web-player` provides the Svelte application that loads a collection, selects a tour by slug, and renders the interactive tour UI
 
+This split keeps parsing, domain modeling, and presentation concerns separate.
+
+## Current Runtime Shape
+
+The repository currently behaves like a small documentation shell for tours.
+
+At runtime, the system:
+
+1. reads a source target from environment
+2. loads either a directory-backed tour collection or a single tour file
+3. exposes collection metadata through layout load functions
+4. selects a route entry by slug
+5. derives the initial step from the URL query
+6. renders the selected tour in the web player
+
+## Data Flow
+
+The end-to-end flow is:
+
+```text
+DIAGRAM_TOUR_SOURCE_TARGET
+  -> parser source-target resolution
+  -> tour discovery or single-file load
+  -> Mermaid node extraction + YAML validation
+  -> resolved collection entries with slugs
+  -> SvelteKit layout data
+  -> route selection by [...tourSlug]
+  -> step selection by ?step=
+  -> interactive player rendering
+```
+
+## Collection and Preview Modes
+
+The runtime supports two loading modes.
+
+### Collection Mode
+
+If the source target is a directory:
+
+- the parser walks the tree recursively
+- each `*.tour.yaml` file is considered a candidate tour
+- valid tours become collection entries
+- invalid tours are recorded as skipped entries
+
+This mode powers the default examples shell.
+
+### Single-File Preview Mode
+
+If the source target is a file:
+
+- the parser loads exactly one tour
+- the layout returns a one-entry collection
+- the web player behaves like a focused author preview
+
+This makes local authoring faster and keeps the routing model consistent.
+
+## Parser Responsibilities
+
+The parser is responsible for more than syntax conversion.
+
+It also owns:
+
+- contextual validation errors
+- Mermaid node indexing
+- replacement of `{{node_id}}` references with Mermaid labels
+- slug generation from relative paths
+- collection discovery and skipped-entry reporting
+
+The parser returns resolved tours rather than raw YAML documents so downstream packages can work with a normalized contract.
+
+## Web Player Responsibilities
+
+The web player owns:
+
+- route and layout loading
+- docs-shell navigation between tours
+- step navigation and deep links
+- interpretation of semantic focus into viewport and highlight behavior
+- theme selection and persistence
+- guided recovery for missing routes
+
+The player consumes resolved models. It does not parse raw Mermaid or YAML files directly.
+
+## Focus Semantics
+
+`focus` is a semantic content signal, not a fixed rendering instruction.
+
+That means:
+
+- the tour contract specifies what the step is about
+- the player decides how to visualize that focus
+- empty-focus steps are allowed and can represent overview states
+
+This keeps the content model stable even as UI behavior evolves.
+
+## Routing Model
+
+The route slug identifies the selected tour.
+
+The optional `?step=` query parameter identifies the initial step:
+
+- missing or invalid values fall back to step one
+- out-of-range values clamp to the valid range
+
+Unknown slugs return a guided `404` page instead of a blank failure.
+
+## Boundaries
+
+The intended boundaries remain:
+
+- `core` stays free of filesystem, YAML, and UI dependencies
+- `parser` handles input loading and validation without absorbing UI concerns
+- `web-player` renders resolved content without re-implementing parser logic
+
+Later versions may add optional integrations, but the current architecture is intentionally centered on a strong parser boundary and a thin UI layer over resolved data.

--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -1,0 +1,126 @@
+# Authoring Guide
+
+This guide describes the current best practices for writing Diagram Tour examples and product tours.
+
+## Start with Stable Mermaid IDs
+
+Every node that may appear in `focus` or `{{references}}` needs an explicit Mermaid ID.
+
+Use readable, stable IDs:
+
+```mermaid
+api_gateway[API Gateway]
+validation_service[Validation Service]
+```
+
+Prefer:
+
+- lowercase snake_case
+- IDs that survive label rewrites
+- IDs that describe the role, not the current copy
+
+Avoid:
+
+- generated-looking IDs
+- IDs that depend on presentation wording
+- renaming IDs just because the label changed
+
+## Keep Tour Text Label-Friendly
+
+Step text can interpolate Mermaid labels with `{{node_id}}`.
+
+Example:
+
+```yaml
+text: >
+  The {{api_gateway}} forwards valid requests to {{validation_service}}.
+```
+
+That keeps the authored copy tied to the diagram label without repeating display names manually.
+
+## Use Focus Intentionally
+
+`focus` is semantic, not a low-level camera instruction.
+
+Use a single focus target when one node should carry the explanation:
+
+```yaml
+focus:
+  - api_gateway
+```
+
+Use multiple focus targets when the relationship between nodes matters more than either node alone:
+
+```yaml
+focus:
+  - payment_service
+  - payment_provider
+```
+
+Use `focus: []` when the step should reset attention, summarize, or let the reader absorb the full diagram:
+
+```yaml
+focus: []
+```
+
+## Write Linear, Readable Steps
+
+Version 1 tours are linear. A good step usually does one of these things:
+
+- introduce one component
+- explain one handoff
+- summarize one phase
+- reset context before the next section
+
+If a step tries to explain too much, split it.
+
+## Organize Tour Files
+
+The current convention is one directory per example:
+
+```text
+examples/payment-flow/
+  payment-flow.mmd
+  payment-flow.tour.yaml
+```
+
+That layout produces a clean slug and keeps related files together.
+
+## Validate Common Failure Cases
+
+The parser rejects:
+
+- missing required root fields
+- empty `steps`
+- non-array `focus`
+- empty or invalid node IDs in `focus`
+- unknown node references in `focus`
+- unknown node references in `text`
+
+Error messages include the source path and step number when possible, so keep steps small enough for that context to stay useful.
+
+## Authoring Workflow
+
+A practical local loop is:
+
+1. point `DIAGRAM_TOUR_SOURCE_TARGET` at a single tour file
+2. run `bun run dev`
+3. iterate on Mermaid and YAML together
+4. run `bun run test`
+5. run `bun run smoke` if viewport or interaction behavior changed
+
+PowerShell example:
+
+```powershell
+$env:DIAGRAM_TOUR_SOURCE_TARGET = "./examples/payment-flow/payment-flow.tour.yaml"
+bun run dev
+```
+
+## Example Fixtures
+
+Use the repository examples as references:
+
+- `payment-flow` for a simple baseline tour
+- `viewport-stability` for empty-focus behavior
+- `viewport-centering` for grouped and edge-position focus behavior
+- `huge-system` for large diagrams and dense label conditions

--- a/docs/runtime-loading.md
+++ b/docs/runtime-loading.md
@@ -1,0 +1,86 @@
+# Runtime Loading
+
+This document explains how Diagram Tour loads tours at runtime today.
+
+## Source Target
+
+The web player loads tours from `DIAGRAM_TOUR_SOURCE_TARGET`.
+
+If that environment variable is not set, the default target is the repository `examples/` directory.
+
+The source target can point to:
+
+- a directory containing one or more `*.tour.yaml` files
+- a single `*.tour.yaml` file for direct author preview
+
+## Directory Mode
+
+When the source target is a directory, the parser:
+
+1. walks the directory tree recursively
+2. discovers every `*.tour.yaml` file
+3. loads and validates each tour
+4. returns a collection of valid entries plus a list of skipped invalid entries
+
+If no valid tours are discovered, loading fails.
+
+Directory mode is the default docs-shell experience used by the web player.
+
+## Single-File Preview
+
+When the source target is a file, the parser:
+
+1. loads exactly that tour
+2. resolves its Mermaid diagram
+3. returns a collection containing a single entry
+
+This mode is useful while authoring a specific tour because it removes unrelated examples from the UI.
+
+## Slug Generation
+
+Each discovered tour entry receives a slug derived from its relative source path.
+
+Examples:
+
+- `examples/payment-flow/payment-flow.tour.yaml` -> `payment-flow`
+- `examples/incident-response/incident-response.tour.yaml` -> `incident-response`
+- `examples/nested/demo.tour.yaml` -> `nested/demo`
+
+If the filename stem matches the containing directory name, the directory path becomes the slug.
+
+## Runtime Flow
+
+The runtime path for the web player is:
+
+1. `+layout.server.ts` reads the source target
+2. `@diagram-tour/parser` loads a resolved collection
+3. layout data exposes both the collection and source-target metadata
+4. `[...tourSlug]/+page.server.ts` selects one entry by slug
+5. the page reads `?step=` to choose the initial step
+6. `tour-player.svelte` renders the tour and keeps navigation in sync with the URL
+
+## Invalid Tours
+
+In directory mode, invalid tours do not stop the whole collection unless every discovered tour is invalid.
+
+Instead, invalid tours are reported in `collection.skipped` with:
+
+- `sourcePath`
+- `error`
+
+That lets the docs shell remain usable while still surfacing authoring problems.
+
+## Route Behavior
+
+The active tour is selected by slug.
+
+The active step is selected by the optional `?step=` query parameter.
+
+Step behavior today:
+
+- missing `step` starts at the first step
+- non-integer `step` falls back to the first step
+- values below range clamp to the first step
+- values above range clamp to the last step
+
+Unknown slugs produce a guided `404` page with a single recovery action back to the available tours.

--- a/docs/tour-spec-v1.md
+++ b/docs/tour-spec-v1.md
@@ -1,31 +1,23 @@
 # Tour Specification v1
 
-This document defines the **version 1 format of a Diagram Tour definition**.
+This document defines version 1 of the Diagram Tour contract.
 
-A tour describes a **guided walkthrough of a Mermaid diagram**.
-
-The format is intentionally minimal for the first version.
+A tour is a guided walkthrough over a Mermaid diagram. Version 1 is intentionally small, linear, and predictable.
 
 Changes to this contract must be accompanied by updated tests and synchronized documentation.
 
----
+## Goals
 
-# Goals of v1
-
-The first version of the specification focuses on:
+Version 1 prioritizes:
 
 - simplicity
 - readability
 - predictable parsing
 - easy authoring
 
-A tour should be easy to write and easy to understand.
+## File Format
 
----
-
-# Tour File Format
-
-Tours are defined using **YAML**.
+Tours are authored as YAML.
 
 Example:
 
@@ -46,87 +38,63 @@ steps:
       The {{validation_service}} verifies the request before processing.
 ```
 
----
+## Root Fields
 
-# Root Fields
+### `version`
 
-## version
+Required.
 
 ```yaml
 version: 1
 ```
 
+Only version `1` is supported.
+
+### `title`
+
 Required.
-
-Defines the specification version.
-
-Only version `1` is supported in this document.
-
----
-
-## title
 
 ```yaml
 title: Payment Flow
 ```
 
+Must be a non-empty string.
+
+### `diagram`
+
 Required.
-
-Human readable name of the tour.
-
-Used for display purposes.
-
----
-
-## diagram
 
 ```yaml
 diagram: ./payment-flow.mmd
 ```
 
-Required.
+Must be a non-empty string path to a Mermaid diagram file.
 
-Path to a Mermaid diagram file.
-
-The diagram must contain nodes with **explicit IDs**.
-
-Example Mermaid node:
+The referenced diagram must contain explicit Mermaid node IDs such as:
 
 ```mermaid
 api_gateway[API Gateway]
 ```
 
-The node ID (`api_gateway`) is used by the tour system.
+### `steps`
 
----
-
-## steps
+Required.
 
 ```yaml
 steps:
   - ...
 ```
 
-Required.
+Must be a non-empty array.
 
-An ordered list of tour steps.
+Tours are linear in version 1. Branching is not supported.
 
-The order defines the progression of the tour.
+## Step Fields
 
-Tours are **linear in version 1**.
+Each step must be an object with:
 
-Branching is not supported.
-
----
-
-# Step Format
-
-Each step must contain:
-
-```text
-focus
-text
-```
+- `focus`
+- `text`
 
 Example:
 
@@ -137,9 +105,9 @@ Example:
     The {{api_gateway}} receives requests from {{client}}.
 ```
 
----
+### `focus`
 
-## focus
+Required.
 
 ```yaml
 focus:
@@ -147,15 +115,12 @@ focus:
   - validation_service
 ```
 
-Required.
-
-Defines which diagram nodes should be emphasized in this step.
-
 Rules:
 
-- Must be an array
-- Can contain zero or more node IDs
-- Each ID must exist in the Mermaid diagram
+- must be an array
+- may contain zero or more node IDs
+- each entry must be a non-empty string
+- each ID must exist in the Mermaid diagram
 
 Valid examples:
 
@@ -174,26 +139,24 @@ focus:
   - payment_provider
 ```
 
----
+`focus: []` is valid and represents a step with no specific node emphasis. A player may use that for an overview, neutral state, or context reset.
 
-## text
+### `text`
+
+Required.
 
 ```yaml
 text: >
   The {{api_gateway}} receives requests from {{client}}.
 ```
 
-Required.
+Must be a non-empty string.
 
-Human readable explanation shown during the step.
+The text may reference diagram nodes through inline references.
 
-The text may reference diagram nodes using **inline references**.
+## Node References
 
----
-
-# Node References
-
-Inside text, nodes are referenced using the following syntax:
+Inside step text, node references use this syntax:
 
 ```text
 {{node_id}}
@@ -205,13 +168,13 @@ Example:
 The {{api_gateway}} sends the request to {{validation_service}}.
 ```
 
-The system resolves these references by:
+Resolution behavior:
 
-1. locating the node ID in the Mermaid diagram
-2. retrieving the node label
-3. replacing the reference with the label
+1. locate the referenced node ID in the Mermaid diagram
+2. read the node label
+3. replace the reference with that label
 
-Example transformation:
+Example:
 
 ```text
 The {{api_gateway}} forwards requests.
@@ -223,38 +186,43 @@ becomes:
 The API Gateway forwards requests.
 ```
 
----
+## Validation Rules
 
-# Validation Rules
+A tour is invalid if any of the following are true:
 
-A tour is considered invalid if:
-
+- the document root is not an object
 - `version` is missing
 - `version` is not `1`
 - `title` is missing
+- `title` is not a non-empty string
 - `diagram` is missing
+- `diagram` is not a non-empty string
 - `steps` is missing
+- `steps` is not an array
 - `steps` is empty
-- `focus` references a node that does not exist
-- `text` references a node that does not exist
+- a step is not an object
+- `focus` is not an array
+- a `focus` entry is empty or not a string
+- a `focus` entry references an unknown Mermaid node ID
+- `text` is missing
+- `text` is not a non-empty string
+- `text` references an unknown Mermaid node ID
 
-Errors should be **descriptive and actionable**.
+Errors should be descriptive and actionable.
 
-Example error:
-
-```text
-Unknown Mermaid node id "validation" referenced in step 2
-```
-
----
-
-# Mermaid Requirements
-
-Version 1 supports **Mermaid flowcharts**.
-
-Nodes must use **explicit IDs**.
+The current parser includes contextual information such as the tour source path and, when relevant, the step number and field.
 
 Example:
+
+```text
+Tour "examples/payment-flow/payment-flow.tour.yaml": step 2 focus references unknown Mermaid node id "validation"
+```
+
+## Mermaid Requirements
+
+Version 1 supports Mermaid flowcharts.
+
+Nodes must use explicit IDs:
 
 ```mermaid
 flowchart LR
@@ -262,7 +230,7 @@ flowchart LR
   api_gateway --> validation_service[Validation Service]
 ```
 
-IDs used by the tour:
+In this example, the usable IDs are:
 
 ```text
 client
@@ -270,47 +238,43 @@ api_gateway
 validation_service
 ```
 
----
+## Focus Semantics
 
-# Behavior of Focus
+The `focus` field is semantic, not a strict UI instruction.
 
-The `focus` field expresses **semantic focus**, not a specific UI effect.
+The contract says which nodes matter for a step. The player decides how to render that meaning.
 
-The player decides how to render focus.
-
-Typical behavior may include:
+Typical UI behavior may include:
 
 - highlighting focused nodes
-- dimming the rest of the diagram
+- dimming non-focused nodes
 - centering the viewport
+- keeping an overview when focus is empty
 
-However, this is **not mandated by the specification**.
+The specification intentionally does not mandate one rendering strategy.
 
----
-
-# Scope of Version 1
+## Scope of Version 1
 
 Supported:
 
 - Mermaid flowcharts
 - YAML tour files
 - sequential tours
-- node highlighting
+- node highlighting or other player-defined focus rendering
 - inline node references in text
+- empty-focus steps
 
 Not supported:
 
 - branching tours
-- multiple diagrams
+- multiple diagrams in one tour
 - audio narration
-- animations
 - conditional steps
+- player-specific viewport instructions in the tour file
 
----
+## Future Directions
 
-# Future Versions
-
-Possible future features include:
+Potential future features include:
 
 - branching tours
 - audio narration
@@ -319,16 +283,8 @@ Possible future features include:
 - interactive steps
 - plugin extensions
 
-These features are intentionally excluded from version 1.
+These are intentionally excluded from version 1.
 
----
+## Philosophy
 
-# Philosophy
-
-The specification prioritizes:
-
-- simplicity
-- readability
-- minimal authoring overhead
-
-Tours should feel like **writing explanations**, not configuring software.
+Version 1 aims to feel like writing an explanation, not configuring a UI runtime.

--- a/examples/huge-system/README.md
+++ b/examples/huge-system/README.md
@@ -2,9 +2,45 @@
 
 This example is intentionally oversized and dense.
 
-Use it to stress-test:
+Use it to validate:
+
 - viewport behavior on a very large diagram
 - edge-label readability under heavy branching
-- multi-focus and neutral-focus behavior
-- layout resilience and dim/highlight stability
+- multi-focus and empty-focus behavior
+- layout resilience during long step text
 - deep linking on large Mermaid renders
+
+## How to Open It
+
+From the default examples shell:
+
+```bash
+bun run dev
+```
+
+Then open the `huge-system` tour in the player.
+
+For a focused author preview:
+
+```bash
+DIAGRAM_TOUR_SOURCE_TARGET=./examples/huge-system/huge-system.tour.yaml bun run dev
+```
+
+PowerShell:
+
+```powershell
+$env:DIAGRAM_TOUR_SOURCE_TARGET = "./examples/huge-system/huge-system.tour.yaml"
+bun run dev
+```
+
+## What It Exercises
+
+This fixture exists to cover scenarios that are easy to miss in smaller diagrams:
+
+- very large SVG bounds
+- dense edge and node layout
+- grouped focus states
+- neutral focus states
+- route deep links into late steps
+
+It is both a demo and a regression fixture for smoke coverage.


### PR DESCRIPTION
## Summary
- refresh the top-level docs so they describe the current runtime behavior instead of the original scaffold
- document runtime loading, slug generation, single-file preview, deep links, focus semantics, and parser validation rules
- add authoring and ADR guidance, plus improve the huge-system example README for local verification

## Verification
- git push origin HEAD:codex/20260311-overnight