### PR TITLE
Add diagram minimap navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The repository currently provides:
 - step text with `{{node_id}}` label interpolation
 - semantic focus steps, including multi-focus and empty-focus steps
 - a Svelte web player with guided navigation
+- a desktop-first navigation minimap with focus markers and viewport panning
 - theme persistence across reloads and direct links
 - guided recovery for unknown tour routes
 - smoke coverage for viewport behavior and large-diagram scenarios

--- a/backlog.md
+++ b/backlog.md
@@ -35,6 +35,9 @@ Cutoff date: 2026-03-17
   - Evidence: `packages/web-player/src/lib/diagram-viewport.ts`
 - Canvas-first layout with top bar, step overlay, and floating browse panel
   - Evidence: `packages/web-player/src/routes/+layout.svelte`
+- Desktop-first navigation minimap with click-to-pan, viewport dragging, focus markers, responsive auto-hide, and persisted collapsed state
+  - Note: the step overlay now stacks above the minimap in the bottom-right overlay column
+  - Evidence: `packages/web-player/src/lib/tour-player.svelte`, `packages/web-player/src/lib/diagram-minimap.ts`, `packages/web-player/test/diagram-minimap.test.ts`
 - Theme toggle and theme persistence
   - Evidence: `packages/web-player/src/routes/+layout.svelte`
 - Recursive discovery of `*.tour.yaml`
@@ -73,8 +76,6 @@ Cutoff date: 2026-03-17
 
 ### Todo
 
-- Navigation minimap
-  - Note: no current implementation was found in the repository
 - Visual step timeline
   - Note: no current implementation was found in the repository
 - Support for more complex diagram types, including Mermaid sequence diagrams
@@ -94,6 +95,8 @@ Cutoff date: 2026-03-17
   - Note: no current implementation was found in the repository
 - Animated viewport transitions
   - Note: no current implementation was found in the repository
+- Step-overlay redesign after minimap integration
+  - Note: the current step overlay now stacks above the minimap and is good enough for v1, but it should be revisited as part of a more intentional navigation/stepper layout
 - Smarter group centering
   - Note: grouped centering exists today, but not a more advanced strategy than the current one
 - Explicit viewport constraints

--- a/docs/testing/smoke-tests.md
+++ b/docs/testing/smoke-tests.md
@@ -261,3 +261,56 @@ Why these checks exist:
 
 - they cover a tour semantic already supported by the v1 contract
 - they protect against subtle viewport regressions on neutral steps
+
+## Navigation Minimap
+
+File: `packages/web-player/smoke/payment-flow.spec.ts`
+
+### Desktop minimap stays visible and tracks the focused step
+
+- Navigates to `payment-flow`
+- Verifies that the minimap shell and surface are visible on desktop
+- Verifies that the current-step focus marker exists
+- Advances to the next step
+- Verifies that the minimap focus marker style changes with the new focus target
+
+Why these checks exist:
+
+- they validate that the minimap is part of the desktop player shell
+- they confirm that the minimap follows guided-step focus, not just raw scroll position
+
+### Clicking the minimap pans the main diagram viewport
+
+- Navigates to `huge-system`
+- Records the current diagram scroll position
+- Clicks near the far corner of the minimap surface
+- Verifies that the main diagram scroll position changes
+
+Why these checks exist:
+
+- they validate the simplest direct-manipulation navigation path
+- they use the browser-visible scroll state of the real canvas instead of internals
+
+### Dragging the minimap viewport rectangle pans the main diagram viewport
+
+- Navigates to `huge-system`
+- Records the current diagram scroll position
+- Drags the minimap viewport rectangle
+- Verifies that the main diagram scroll position changes
+
+Why these checks exist:
+
+- they protect the higher-precision navigation mode of the minimap
+- they ensure the minimap is not just a passive indicator
+
+### Small screens hide the minimap automatically
+
+- Shrinks the viewport to a mobile-sized width
+- Navigates to `payment-flow`
+- Verifies that the step overlay still exists
+- Verifies that the minimap does not render
+
+Why these checks exist:
+
+- they protect the desktop-first scope of minimap v1
+- they ensure mobile layouts do not inherit a cramped or accidental minimap UI

--- a/packages/web-player/smoke/payment-flow.spec.ts
+++ b/packages/web-player/smoke/payment-flow.spec.ts
@@ -232,6 +232,69 @@ test("empty-focus steps keep viewport behavior stable", async ({ page }) => {
   expect(neutralScrollTop).toBe(0);
 });
 
+test("desktop minimap stays visible and tracks the focused step", async ({ page }) => {
+  await page.goto("/payment-flow");
+  await expectDiagramVisible(page);
+  await expect(page.getByTestId("minimap-shell")).toBeVisible();
+  await expect(page.getByTestId("minimap-surface")).toBeVisible();
+  expect(await page.getByTestId("minimap-node-marker").count()).toBeGreaterThan(3);
+  await expect(page.getByTestId("minimap-focus-marker")).toHaveCount(1);
+
+  const initialMarkerStyle = await page.getByTestId("minimap-focus-marker").getAttribute("style");
+
+  await page.getByTestId("next-button").click();
+  await expect(page.getByTestId("step-text")).toContainText("Validation Service");
+  await expect
+    .poll(async () => page.getByTestId("minimap-focus-marker").getAttribute("style"))
+    .not.toBe(initialMarkerStyle);
+});
+
+test("clicking the minimap pans the main diagram viewport", async ({ page }) => {
+  await page.goto("/huge-system");
+  await expectDiagramVisible(page);
+  await expect(page.getByTestId("minimap-surface")).toBeVisible();
+
+  const previousScroll = await readDiagramScrollPosition(page);
+  const minimapBox = await page.getByTestId("minimap-surface").boundingBox();
+
+  assertLayoutBox(minimapBox);
+  await page.getByTestId("minimap-surface").click({
+    position: {
+      x: minimapBox.width - 10,
+      y: minimapBox.height - 10
+    }
+  });
+
+  await expect.poll(async () => readDiagramScrollPosition(page)).not.toEqual(previousScroll);
+});
+
+test("dragging the minimap viewport rectangle pans the main diagram viewport", async ({ page }) => {
+  await page.goto("/huge-system");
+  await expectDiagramVisible(page);
+  await expect(page.getByTestId("minimap-viewport-rect")).toBeVisible();
+
+  const previousScroll = await readDiagramScrollPosition(page);
+  const viewportRectBox = await page.getByTestId("minimap-viewport-rect").boundingBox();
+
+  assertLayoutBox(viewportRectBox);
+  await page.mouse.move(viewportRectBox.x + viewportRectBox.width / 2, viewportRectBox.y + viewportRectBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(viewportRectBox.x + viewportRectBox.width / 2 + 36, viewportRectBox.y + viewportRectBox.height / 2 + 24, {
+    steps: 4
+  });
+  await page.mouse.up();
+
+  await expect.poll(async () => readDiagramScrollPosition(page)).not.toEqual(previousScroll);
+});
+
+test("small screens hide the minimap automatically", async ({ page }) => {
+  await page.setViewportSize({ height: 900, width: 640 });
+  await page.goto("/payment-flow");
+  await expectDiagramVisible(page);
+  await expect(page.getByTestId("step-overlay")).toBeVisible();
+  await expect(page.getByTestId("minimap-shell")).toHaveCount(0);
+});
+
 async function expectDiagramVisible(page: Page): Promise<void> {
   await expect(page.locator('[data-testid="diagram-container"] svg')).toBeVisible();
 }
@@ -365,6 +428,16 @@ async function readNodeAxisSize(
   assertLayoutBox(nodeBox);
 
   return nodeBox[axis];
+}
+
+async function readDiagramScrollPosition(page: Page): Promise<{
+  scrollLeft: number;
+  scrollTop: number;
+}> {
+  return page.getByTestId("diagram-container").evaluate((element) => ({
+    scrollLeft: element.scrollLeft,
+    scrollTop: element.scrollTop
+  }));
 }
 
 function assertLayoutBox(input: {

--- a/packages/web-player/src/lib/diagram-minimap.ts
+++ b/packages/web-player/src/lib/diagram-minimap.ts
@@ -1,0 +1,301 @@
+export interface DiagramMinimapNodeRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface DiagramMinimapMetrics {
+  contentHeight: number;
+  contentWidth: number;
+  scrollLeft: number;
+  scrollTop: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
+export interface DiagramMinimapSize {
+  maxHeight: number;
+  maxWidth: number;
+}
+
+export interface DiagramMinimapRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface DiagramMinimapGeometry {
+  bounds: DiagramMinimapRect;
+  nodeRects: DiagramMinimapRect[];
+  focusRects: DiagramMinimapRect[];
+  viewportRect: DiagramMinimapRect;
+}
+
+export function createDiagramMinimapGeometry(input: {
+  nodeRects: DiagramMinimapNodeRect[];
+  focusedNodeRects: DiagramMinimapNodeRect[];
+  metrics: DiagramMinimapMetrics;
+  minimapSize: DiagramMinimapSize;
+}): DiagramMinimapGeometry | null {
+  const scale = readMinimapScale(input.metrics, input.minimapSize);
+
+  if (scale === null) {
+    return null;
+  }
+
+  const bounds = createBoundsRect(input.metrics, scale);
+
+  return {
+    bounds,
+    nodeRects: input.nodeRects.filter(isValidNodeRect).map((rect) => scaleNodeRect(rect, scale, bounds)),
+    focusRects: input.focusedNodeRects
+      .filter(isValidNodeRect)
+      .map((rect) => scaleNodeRect(rect, scale, bounds)),
+    viewportRect: createViewportRect(input.metrics, scale, bounds)
+  };
+}
+
+export function createMinimapCenterScrollPosition(input: {
+  metrics: DiagramMinimapMetrics;
+  minimapPoint: { x: number; y: number };
+  minimapSize: DiagramMinimapSize;
+}): {
+  scrollLeft: number;
+  scrollTop: number;
+} | null {
+  const scale = readMinimapScale(input.metrics, input.minimapSize);
+
+  if (scale === null) {
+    return null;
+  }
+
+  return createScrollPosition({
+    metrics: input.metrics,
+    nextLeft: input.minimapPoint.x / scale - input.metrics.viewportWidth / 2,
+    nextTop: input.minimapPoint.y / scale - input.metrics.viewportHeight / 2
+  });
+}
+
+export function createMinimapViewportScrollPosition(input: {
+  metrics: DiagramMinimapMetrics;
+  minimapSize: DiagramMinimapSize;
+  viewportOrigin: { x: number; y: number };
+}): {
+  scrollLeft: number;
+  scrollTop: number;
+} | null {
+  const scale = readMinimapScale(input.metrics, input.minimapSize);
+
+  if (scale === null) {
+    return null;
+  }
+
+  return createScrollPosition({
+    metrics: input.metrics,
+    nextLeft: input.viewportOrigin.x / scale,
+    nextTop: input.viewportOrigin.y / scale
+  });
+}
+
+export function readDiagramMinimapMetrics(input: {
+  container: HTMLElement;
+  content: HTMLElement;
+}): DiagramMinimapMetrics {
+  return {
+    contentHeight: readExtent(input.content, "height"),
+    contentWidth: readExtent(input.content, "width"),
+    scrollLeft: sanitizeFiniteValue(input.container.scrollLeft),
+    scrollTop: sanitizeFiniteValue(input.container.scrollTop),
+    viewportHeight: sanitizeFiniteValue(input.container.clientHeight),
+    viewportWidth: sanitizeFiniteValue(input.container.clientWidth)
+  };
+}
+
+export function readDiagramMinimapNodeRects(input: {
+  content: HTMLElement;
+  focusedNodeIds: string[];
+}): DiagramMinimapNodeRect[] {
+  const contentRect = input.content.getBoundingClientRect();
+
+  return input.focusedNodeIds
+    .map((nodeId) => input.content.querySelector<HTMLElement>(`[data-node-id="${nodeId}"]`))
+    .flatMap((element) => (element === null ? [] : [toNodeRect(contentRect, element)]));
+}
+
+function createBoundsRect(
+  metrics: DiagramMinimapMetrics,
+  scale: number
+): DiagramMinimapRect {
+  return {
+    left: 0,
+    top: 0,
+    width: roundToPixel(metrics.contentWidth * scale),
+    height: roundToPixel(metrics.contentHeight * scale)
+  };
+}
+
+function createViewportRect(
+  metrics: DiagramMinimapMetrics,
+  scale: number,
+  bounds: DiagramMinimapRect
+): DiagramMinimapRect {
+  const viewportWidth = Math.min(bounds.width, roundToPixel(metrics.viewportWidth * scale));
+  const viewportHeight = Math.min(bounds.height, roundToPixel(metrics.viewportHeight * scale));
+
+  return {
+    left: clampRectOrigin(roundToPixel(metrics.scrollLeft * scale), bounds.width - viewportWidth),
+    top: clampRectOrigin(roundToPixel(metrics.scrollTop * scale), bounds.height - viewportHeight),
+    width: viewportWidth,
+    height: viewportHeight
+  };
+}
+
+function scaleNodeRect(
+  rect: DiagramMinimapNodeRect,
+  scale: number,
+  bounds: DiagramMinimapRect
+): DiagramMinimapRect {
+  const width = clampRectSize(roundToPixel(rect.width * scale), bounds.width);
+  const height = clampRectSize(roundToPixel(rect.height * scale), bounds.height);
+
+  return {
+    left: clampRectOrigin(roundToPixel(rect.left * scale), bounds.width - width),
+    top: clampRectOrigin(roundToPixel(rect.top * scale), bounds.height - height),
+    width,
+    height
+  };
+}
+
+function createScrollPosition(input: {
+  metrics: DiagramMinimapMetrics;
+  nextLeft: number;
+  nextTop: number;
+}): {
+  scrollLeft: number;
+  scrollTop: number;
+} {
+  return {
+    scrollLeft: clampScrollTarget(
+      input.nextLeft,
+      input.metrics.contentWidth - input.metrics.viewportWidth
+    ),
+    scrollTop: clampScrollTarget(
+      input.nextTop,
+      input.metrics.contentHeight - input.metrics.viewportHeight
+    )
+  };
+}
+
+function readMinimapScale(
+  metrics: DiagramMinimapMetrics,
+  minimapSize: DiagramMinimapSize
+): number | null {
+  if (!hasStableMetrics(metrics) || !hasStableMinimapSize(minimapSize)) {
+    return null;
+  }
+
+  return Math.min(
+    minimapSize.maxWidth / metrics.contentWidth,
+    minimapSize.maxHeight / metrics.contentHeight
+  );
+}
+
+function hasStableMetrics(metrics: DiagramMinimapMetrics): boolean {
+  return hasStableContentMetrics(metrics) && hasStableViewportMetrics(metrics);
+}
+
+function hasStableMinimapSize(minimapSize: DiagramMinimapSize): boolean {
+  return isFinitePositive(minimapSize.maxWidth) && isFinitePositive(minimapSize.maxHeight);
+}
+
+function toNodeRect(contentRect: DOMRect, element: HTMLElement): DiagramMinimapNodeRect {
+  const elementRect = element.getBoundingClientRect();
+
+  return {
+    left: elementRect.left - contentRect.left,
+    top: elementRect.top - contentRect.top,
+    width: elementRect.width,
+    height: elementRect.height
+  };
+}
+
+function clampScrollTarget(target: number, maxScroll: number): number {
+  const sanitizedMaxScroll = Math.max(0, sanitizeFiniteValue(maxScroll));
+  const sanitizedTarget = sanitizeFiniteValue(target);
+
+  if (sanitizedTarget < 0) {
+    return 0;
+  }
+
+  if (sanitizedTarget > sanitizedMaxScroll) {
+    return sanitizedMaxScroll;
+  }
+
+  return Math.round(sanitizedTarget);
+}
+
+function clampRectOrigin(value: number, maxValue: number): number {
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > maxValue) {
+    return roundToPixel(maxValue);
+  }
+
+  return roundToPixel(value);
+}
+
+function clampRectSize(value: number, maxValue: number): number {
+  if (value > maxValue) {
+    return roundToPixel(maxValue);
+  }
+
+  return roundToPixel(Math.max(0, value));
+}
+
+function isValidNodeRect(rect: DiagramMinimapNodeRect): boolean {
+  return hasFiniteNodeOrigin(rect) && hasFiniteNodeSize(rect);
+}
+
+function hasStableContentMetrics(metrics: DiagramMinimapMetrics): boolean {
+  return isFinitePositive(metrics.contentWidth) && isFinitePositive(metrics.contentHeight);
+}
+
+function hasStableViewportMetrics(metrics: DiagramMinimapMetrics): boolean {
+  return isFinitePositive(metrics.viewportWidth) && isFinitePositive(metrics.viewportHeight);
+}
+
+function hasFiniteNodeOrigin(rect: DiagramMinimapNodeRect): boolean {
+  return Number.isFinite(rect.left) && Number.isFinite(rect.top);
+}
+
+function hasFiniteNodeSize(rect: DiagramMinimapNodeRect): boolean {
+  return isFinitePositive(rect.width) && isFinitePositive(rect.height);
+}
+
+function isFinitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function sanitizeFiniteValue(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function roundToPixel(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function readExtent(content: HTMLElement, axis: "height" | "width"): number {
+  return sanitizeFiniteValue(readScrollExtent(content, axis) || readClientExtent(content, axis));
+}
+
+function readScrollExtent(content: HTMLElement, axis: "height" | "width"): number {
+  return axis === "height" ? content.scrollHeight : content.scrollWidth;
+}
+
+function readClientExtent(content: HTMLElement, axis: "height" | "width"): number {
+  return axis === "height" ? content.clientHeight : content.clientWidth;
+}

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -12,10 +12,26 @@
     getMermaidErrorMessage,
     renderMermaidDiagram
   } from "$lib/mermaid-diagram";
+  import {
+    createDiagramMinimapGeometry,
+    createMinimapCenterScrollPosition,
+    createMinimapViewportScrollPosition,
+    readDiagramMinimapMetrics,
+    readDiagramMinimapNodeRects,
+    type DiagramMinimapGeometry,
+    type DiagramMinimapMetrics
+  } from "$lib/diagram-minimap";
   import { focusDiagramViewport } from "$lib/diagram-viewport";
   import { createFocusGroup } from "$lib/focus-group";
   import { createTourPlayer } from "$lib/player-state";
   import type { ResolvedDiagramTour } from "@diagram-tour/core";
+
+  const MINIMAP_BREAKPOINT = 720;
+  const MINIMAP_STORAGE_KEY = "diagram-tour:minimap-collapsed";
+  const MINIMAP_SIZE = {
+    maxHeight: 160,
+    maxWidth: 220
+  } as const;
 
   export let initialStepIndex: number;
   export let selectedSlug: string;
@@ -28,9 +44,21 @@
   let state = player.getState();
   let diagramContainer: HTMLDivElement;
   let diagramContent: HTMLDivElement;
+  let minimapSurface: HTMLDivElement;
   let diagramError = "";
   let hasRenderedDiagram = false;
+  let isCompactViewport = false;
+  let isMinimapCollapsed = false;
+  let minimapGeometry: DiagramMinimapGeometry | null = null;
   let previousInitialStepIndex = initialStepIndex;
+  let viewportDragState:
+    | {
+        didDrag: boolean;
+        offsetX: number;
+        offsetY: number;
+        pointerId: number;
+      }
+    | null = null;
 
   async function goPrevious(): Promise<void> {
     state = player.goPrevious();
@@ -68,20 +96,25 @@
       content: currentContext.content,
       focusGroup
     });
+    updateMinimapGeometry();
   }
 
-  onMount(async () => {
-    try {
-      await renderMermaidDiagram({
-        container: diagramContent,
-        diagram: tour.diagram
-      });
-      hasRenderedDiagram = true;
-      await syncFocusState();
-    } catch (_error) {
-      diagramError = getMermaidErrorMessage();
-      toast.error(diagramError);
-    }
+  onMount(() => {
+    hydrateViewportMode();
+    hydrateMinimapState();
+
+    const cleanupWindow = attachWindowListeners();
+    const cleanupScroll = attachDiagramScrollListener();
+    const cleanupResizeObserver = attachDiagramResizeObserver();
+
+    void renderInitialDiagram();
+
+    return () => {
+      cleanupWindow();
+      cleanupScroll();
+      cleanupResizeObserver();
+      detachViewportDrag();
+    };
   });
 
   $: if (initialStepIndex !== previousInitialStepIndex) {
@@ -125,6 +158,457 @@
   function handleTourIdentityClick(): void {
     dispatch("togglebrowse");
   }
+
+  function toggleMinimap(): void {
+    isMinimapCollapsed = !isMinimapCollapsed;
+    persistMinimapState();
+  }
+
+  async function renderInitialDiagram(): Promise<void> {
+    try {
+      await renderMermaidDiagram({
+        container: diagramContent,
+        diagram: tour.diagram
+      });
+      hasRenderedDiagram = true;
+      await syncFocusState();
+    } catch (_error) {
+      diagramError = getMermaidErrorMessage();
+      toast.error(diagramError);
+    }
+  }
+
+  function hydrateViewportMode(): void {
+    isCompactViewport = typeof window !== "undefined" && window.innerWidth < MINIMAP_BREAKPOINT;
+  }
+
+  function hydrateMinimapState(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    isMinimapCollapsed = window.localStorage.getItem(MINIMAP_STORAGE_KEY) === "true";
+  }
+
+  function persistMinimapState(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(MINIMAP_STORAGE_KEY, String(isMinimapCollapsed));
+  }
+
+  function attachWindowListeners(): () => void {
+    if (typeof window === "undefined") {
+      return () => undefined;
+    }
+
+    const handleResize = (): void => {
+      hydrateViewportMode();
+      updateMinimapGeometry();
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }
+
+  function attachDiagramScrollListener(): () => void {
+    const container = readBoundElement(diagramContainer);
+
+    if (container === null) {
+      return () => undefined;
+    }
+
+    const handleScroll = (): void => {
+      updateMinimapGeometry();
+    };
+
+    container.addEventListener("scroll", handleScroll);
+
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }
+
+  function attachDiagramResizeObserver(): () => void {
+    if (typeof ResizeObserver === "undefined") {
+      return () => undefined;
+    }
+
+    const currentContext = readDiagramContext();
+
+    if (currentContext === null) {
+      return () => undefined;
+    }
+
+    const observer = new ResizeObserver(() => {
+      updateMinimapGeometry();
+    });
+
+    observer.observe(currentContext.container);
+    observer.observe(currentContext.content);
+
+    return () => {
+      observer.disconnect();
+    };
+  }
+
+  function updateMinimapGeometry(): void {
+    minimapGeometry = shouldHideMinimapGeometry() ? null : createCurrentMinimapGeometry();
+  }
+
+  function handleMinimapSurfacePointerDown(event: PointerEvent): void {
+    const metrics = readCurrentMinimapMetrics();
+    const minimapPoint = readMinimapPoint(event);
+
+    if (metrics === null || minimapPoint === null) {
+      return;
+    }
+
+    const nextPosition = createMinimapCenterScrollPosition({
+      metrics,
+      minimapPoint,
+      minimapSize: MINIMAP_SIZE
+    });
+
+    writeDiagramScrollPosition(nextPosition);
+  }
+
+  function handleViewportPointerDown(event: PointerEvent): void {
+    const nextDragState = readViewportDragState(event);
+
+    if (nextDragState === null) {
+      return;
+    }
+
+    viewportDragState = nextDragState;
+    captureViewportPointer(event);
+    window.addEventListener("pointermove", handleViewportPointerMove);
+    window.addEventListener("pointerup", handleViewportPointerUp);
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  function handleViewportPointerMove(event: PointerEvent): void {
+    const dragInput = readViewportDragInput(event);
+
+    if (dragInput === null) {
+      return;
+    }
+
+    viewportDragState = markViewportDragStateAsDragged(dragInput.dragState);
+
+    const nextPosition = createMinimapViewportScrollPosition({
+      metrics: dragInput.metrics,
+      minimapSize: MINIMAP_SIZE,
+      viewportOrigin: dragInput.viewportOrigin
+    });
+
+    writeDiagramScrollPosition(nextPosition);
+  }
+
+  function handleViewportPointerUp(event: PointerEvent): void {
+    if (viewportDragState?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    detachViewportDrag();
+  }
+
+  function detachViewportDrag(): void {
+    viewportDragState = null;
+    window.removeEventListener("pointermove", handleViewportPointerMove);
+    window.removeEventListener("pointerup", handleViewportPointerUp);
+  }
+
+  function readCurrentMinimapMetrics(): DiagramMinimapMetrics | null {
+    const currentContext = readDiagramContext();
+
+    return currentContext === null
+      ? null
+      : readDiagramMinimapMetrics({
+          container: currentContext.container,
+          content: currentContext.content
+        });
+  }
+
+  function readMinimapPoint(event: MouseEvent | PointerEvent): { x: number; y: number } | null {
+    const surface = readBoundElement(minimapSurface);
+
+    if (surface === null) {
+      return null;
+    }
+
+    const rect = surface.getBoundingClientRect();
+
+    return {
+      x: clampMinimapCoordinate(event.clientX - rect.left, rect.width),
+      y: clampMinimapCoordinate(event.clientY - rect.top, rect.height)
+    };
+  }
+
+  function clampMinimapCoordinate(value: number, maxValue: number): number {
+    if (value < 0) {
+      return 0;
+    }
+
+    if (value > maxValue) {
+      return maxValue;
+    }
+
+    return value;
+  }
+
+  function writeDiagramScrollPosition(position: {
+    scrollLeft: number;
+    scrollTop: number;
+  } | null): void {
+    const container = readBoundElement(diagramContainer);
+
+    if (container === null || position === null) {
+      return;
+    }
+
+    applyDiagramScrollPosition(container, position);
+    updateMinimapGeometry();
+  }
+
+  function formatMinimapRectStyle(rect: {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+  }): string {
+    return `left:${rect.left}px;top:${rect.top}px;width:${rect.width}px;height:${rect.height}px;`;
+  }
+
+  function formatMinimapBoundsStyle(bounds: {
+    height: number;
+    width: number;
+  }): string {
+    return `width:${bounds.width}px;height:${bounds.height}px;`;
+  }
+
+  function shouldHideMinimapGeometry(): boolean {
+    return isCompactViewport || !hasRenderedDiagram || readDiagramContext() === null;
+  }
+
+  function createCurrentMinimapGeometry(): DiagramMinimapGeometry | null {
+    const currentContext = readDiagramContext();
+
+    return currentContext === null
+      ? null
+      : createDiagramMinimapGeometry({
+          nodeRects: readDiagramMinimapNodeRects({
+            content: currentContext.content,
+            focusedNodeIds: tour.diagram.nodes.map((node) => node.id)
+          }),
+          focusedNodeRects: readDiagramMinimapNodeRects({
+            content: currentContext.content,
+            focusedNodeIds: state.focusedNodeIds
+          }),
+          metrics: readDiagramMinimapMetrics({
+            container: currentContext.container,
+            content: currentContext.content
+          }),
+          minimapSize: MINIMAP_SIZE
+        });
+  }
+
+  function readViewportDragState(event: PointerEvent):
+    | {
+        didDrag: boolean;
+        offsetX: number;
+        offsetY: number;
+        pointerId: number;
+      }
+    | null {
+    const viewportRect = event.currentTarget;
+
+    if (minimapGeometry === null || !(viewportRect instanceof HTMLElement)) {
+      return null;
+    }
+
+    return {
+      didDrag: false,
+      offsetX: event.clientX - viewportRect.getBoundingClientRect().left,
+      offsetY: event.clientY - viewportRect.getBoundingClientRect().top,
+      pointerId: event.pointerId
+    };
+  }
+
+  function captureViewportPointer(event: PointerEvent): void {
+    const viewportRect = event.currentTarget;
+
+    if (viewportRect instanceof HTMLElement && typeof viewportRect.setPointerCapture === "function") {
+      viewportRect.setPointerCapture(event.pointerId);
+    }
+  }
+
+  function matchesViewportDragPointer(event: PointerEvent): boolean {
+    return viewportDragState !== null && event.pointerId === viewportDragState.pointerId;
+  }
+
+  function readCurrentViewportDragState(event: PointerEvent):
+    | {
+        didDrag: boolean;
+        offsetX: number;
+        offsetY: number;
+        pointerId: number;
+      }
+    | null {
+    return matchesViewportDragPointer(event) ? viewportDragState : null;
+  }
+
+  function markViewportDragStateAsDragged(input: {
+    didDrag: boolean;
+    offsetX: number;
+    offsetY: number;
+    pointerId: number;
+  }): {
+    didDrag: boolean;
+    offsetX: number;
+    offsetY: number;
+    pointerId: number;
+  } {
+    return {
+      ...input,
+      didDrag: true
+    };
+  }
+
+  function readViewportDragInput(event: PointerEvent): {
+    dragState: {
+      didDrag: boolean;
+      offsetX: number;
+      offsetY: number;
+      pointerId: number;
+    };
+    metrics: DiagramMinimapMetrics;
+    viewportOrigin: {
+      x: number;
+      y: number;
+    };
+  } | null {
+    const dragState = readCurrentViewportDragState(event);
+    const metrics = readCurrentMinimapMetrics();
+    const viewportOrigin = readDraggedViewportOrigin(event);
+
+    if (hasMissingViewportDragInput(dragState, metrics, viewportOrigin)) {
+      return null;
+    }
+
+    return createViewportDragInputPayload({
+      dragState,
+      metrics,
+      viewportOrigin
+    });
+  }
+
+  function hasMissingViewportDragInput(
+    dragState: {
+      didDrag: boolean;
+      offsetX: number;
+      offsetY: number;
+      pointerId: number;
+    } | null,
+    metrics: DiagramMinimapMetrics | null,
+    viewportOrigin: {
+      x: number;
+      y: number;
+    } | null
+  ): boolean {
+    return [dragState, metrics, viewportOrigin].some((value) => value === null);
+  }
+
+  function createViewportDragInputPayload(input: {
+    dragState: {
+      didDrag: boolean;
+      offsetX: number;
+      offsetY: number;
+      pointerId: number;
+    } | null;
+    metrics: DiagramMinimapMetrics | null;
+    viewportOrigin:
+      | {
+          x: number;
+          y: number;
+        }
+      | null;
+  }): {
+    dragState: {
+      didDrag: boolean;
+      offsetX: number;
+      offsetY: number;
+      pointerId: number;
+    };
+    metrics: DiagramMinimapMetrics;
+    viewportOrigin: {
+      x: number;
+      y: number;
+    };
+  } {
+    return {
+      dragState: input.dragState as {
+        didDrag: boolean;
+        offsetX: number;
+        offsetY: number;
+        pointerId: number;
+      },
+      metrics: input.metrics as DiagramMinimapMetrics,
+      viewportOrigin: input.viewportOrigin as {
+        x: number;
+        y: number;
+      }
+    };
+  }
+
+  function readDraggedViewportOrigin(event: PointerEvent): { x: number; y: number } | null {
+    const minimapPoint = readMinimapPoint(event);
+
+    if (minimapPoint === null || viewportDragState === null) {
+      return null;
+    }
+
+    return {
+      x: minimapPoint.x - viewportDragState.offsetX,
+      y: minimapPoint.y - viewportDragState.offsetY
+    };
+  }
+
+  function applyDiagramScrollPosition(
+    container: HTMLDivElement,
+    position: {
+      scrollLeft: number;
+      scrollTop: number;
+    }
+  ): void {
+    if (typeof container.scrollTo === "function") {
+      scrollDiagramContainer(container, position);
+
+      return;
+    }
+
+    container.scrollLeft = position.scrollLeft;
+    container.scrollTop = position.scrollTop;
+  }
+
+  function scrollDiagramContainer(
+    container: HTMLDivElement,
+    position: {
+      scrollLeft: number;
+      scrollTop: number;
+    }
+  ): void {
+    container.scrollTo({
+      behavior: "auto",
+      left: position.scrollLeft,
+      top: position.scrollTop
+    });
+  }
 </script>
 
 <section class="player-canvas" data-testid="player-canvas">
@@ -147,31 +631,91 @@
       ></div>
     </div>
 
-    <aside class="step-panel step-panel--overlay" data-testid="step-overlay">
-      <p class="step-count">Step {state.step.index} of {tour.steps.length}</p>
-      <p data-testid="step-text" class="step-text">{state.step.text}</p>
+    <div class="canvas-overlay-stack" data-testid="canvas-overlay-stack">
+      <aside class="step-panel step-panel--overlay" data-testid="step-overlay">
+        <p class="step-count">Step {state.step.index} of {tour.steps.length}</p>
+        <p data-testid="step-text" class="step-text">{state.step.text}</p>
 
-      <div class="controls">
-        <button
-          type="button"
-          class="button button--secondary"
-          on:click={goPrevious}
-          disabled={!state.canGoPrevious}
-          data-testid="previous-button"
+        <div class="controls">
+          <button
+            type="button"
+            class="button button--secondary"
+            on:click={goPrevious}
+            disabled={!state.canGoPrevious}
+            data-testid="previous-button"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            class="button"
+            on:click={goNext}
+            disabled={!state.canGoNext}
+            data-testid="next-button"
+          >
+            Next
+          </button>
+        </div>
+      </aside>
+
+      {#if !isCompactViewport}
+        <aside
+          class:minimap-shell--collapsed={isMinimapCollapsed}
+          class="minimap-shell"
+          data-testid="minimap-shell"
         >
-          Previous
-        </button>
-        <button
-          type="button"
-          class="button"
-          on:click={goNext}
-          disabled={!state.canGoNext}
-          data-testid="next-button"
-        >
-          Next
-        </button>
-      </div>
-    </aside>
+          <div class="minimap-shell__header">
+            <p class="minimap-shell__label">Navigation minimap</p>
+            <button
+              type="button"
+              class="minimap-shell__toggle"
+              data-testid="minimap-toggle"
+              aria-expanded={!isMinimapCollapsed}
+              on:click={toggleMinimap}
+            >
+              {isMinimapCollapsed ? "Show" : "Hide"}
+            </button>
+          </div>
+
+          {#if !isMinimapCollapsed && minimapGeometry !== null}
+            <div
+              bind:this={minimapSurface}
+              class="minimap-surface"
+              role="group"
+              aria-label="Navigation minimap"
+              data-testid="minimap-surface"
+              style={formatMinimapBoundsStyle(minimapGeometry.bounds)}
+              on:pointerdown={handleMinimapSurfacePointerDown}
+            >
+              {#each minimapGeometry.nodeRects as rect, index (`node-${index}`)}
+                <div
+                  class="minimap-node-marker"
+                  data-testid="minimap-node-marker"
+                  style={formatMinimapRectStyle(rect)}
+                ></div>
+              {/each}
+
+              {#each minimapGeometry.focusRects as rect, index (index)}
+                <div
+                  class="minimap-focus-marker"
+                  data-testid="minimap-focus-marker"
+                  style={formatMinimapRectStyle(rect)}
+                ></div>
+              {/each}
+
+              <button
+                type="button"
+                class="minimap-viewport-rect"
+                data-testid="minimap-viewport-rect"
+                aria-label="Drag viewport"
+                style={formatMinimapRectStyle(minimapGeometry.viewportRect)}
+                on:pointerdown={handleViewportPointerDown}
+              ></button>
+            </div>
+          {/if}
+        </aside>
+      {/if}
+    </div>
 
     {#if diagramError.length > 0}
       <p data-testid="diagram-error" class="diagram-error diagram-error--overlay">{diagramError}</p>

--- a/packages/web-player/src/styles/components/cards.css
+++ b/packages/web-player/src/styles/components/cards.css
@@ -17,11 +17,8 @@
   background: color-mix(in srgb, var(--color-surface) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 48%, var(--color-border));
   border-radius: var(--radius-card);
-  bottom: 0.85rem;
   box-shadow: var(--shadow-overlay, var(--shadow-soft));
-  position: absolute;
-  right: 0.85rem;
-  z-index: 15;
+  position: relative;
 }
 
 .step-text {
@@ -50,6 +47,22 @@
   border-radius: var(--radius-card);
   box-shadow: none;
   position: relative;
+}
+
+.canvas-overlay-stack {
+  align-items: flex-end;
+  bottom: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.72rem;
+  pointer-events: none;
+  position: absolute;
+  right: 0.85rem;
+  z-index: 15;
+}
+
+.canvas-overlay-stack > * {
+  pointer-events: auto;
 }
 
 .tour-identity {
@@ -127,16 +140,154 @@
   z-index: 9;
 }
 
+.minimap-shell {
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-overlay, var(--shadow-soft));
+  display: grid;
+  gap: 0.72rem;
+  min-width: 13.5rem;
+  padding: 0.72rem 0.78rem;
+}
+
+.minimap-shell--collapsed {
+  gap: 0;
+  min-width: 0;
+}
+
+.minimap-shell__header {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.minimap-shell__label {
+  color: var(--color-text-secondary, var(--color-muted));
+  font-family: var(--font-family-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.minimap-shell__toggle {
+  appearance: none;
+  background: color-mix(in srgb, var(--color-bg-soft) 84%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
+  border-radius: var(--radius-control);
+  color: var(--color-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  min-height: 2rem;
+  padding: 0.3rem 0.7rem;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.minimap-shell__toggle:hover,
+.minimap-shell__toggle:focus-visible {
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border-color: color-mix(in srgb, var(--color-node-focus-stroke) 42%, var(--color-border));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 22%, transparent);
+}
+
+.minimap-surface {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--color-bg-soft) 92%, var(--color-surface)), color-mix(in srgb, var(--color-bg-main) 94%, var(--color-surface))),
+    radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--color-bg-glow) 28%, transparent), transparent 42%);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
+  border-radius: calc(var(--radius-card-tight) * 0.95);
+  cursor: crosshair;
+  overflow: hidden;
+  position: relative;
+}
+
+.minimap-node-marker {
+  background: color-mix(in srgb, var(--color-bg-soft) 84%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 52%, transparent);
+  border-radius: 0.3rem;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-bg-main) 24%, transparent);
+  opacity: 0.94;
+  position: absolute;
+}
+
+.minimap-focus-marker {
+  background: color-mix(in srgb, var(--color-node-focus-fill) 76%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-node-focus-stroke) 94%, transparent);
+  border-radius: 0.3rem;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 18%, transparent),
+    0 0 12px color-mix(in srgb, var(--color-node-focus-stroke) 18%, transparent);
+  position: absolute;
+}
+
+.minimap-viewport-rect {
+  appearance: none;
+  background: color-mix(in srgb, var(--color-node-focus-fill) 20%, transparent);
+  border: 1px solid color-mix(in srgb, white 78%, var(--color-node-focus-stroke));
+  border-radius: 0.42rem;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 48%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 22%, transparent);
+  cursor: grab;
+  min-height: 0;
+  min-width: 0;
+  padding: 0;
+  position: absolute;
+}
+
+.minimap-viewport-rect:active {
+  cursor: grabbing;
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .minimap-surface {
+  background:
+    linear-gradient(180deg, rgb(38 46 64 / 92%), rgb(24 30 43 / 94%)),
+    radial-gradient(circle at 28% 22%, rgb(138 162 255 / 12%), transparent 46%);
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .minimap-node-marker {
+  background: rgb(116 130 162 / 34%);
+  border-color: rgb(164 179 214 / 38%);
+  box-shadow:
+    inset 0 0 0 1px rgb(206 217 246 / 6%),
+    0 0 0 1px rgb(10 14 22 / 18%);
+  opacity: 1;
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .minimap-focus-marker {
+  background: rgb(86 112 198 / 64%);
+  border-color: rgb(151 174 255 / 96%);
+  box-shadow:
+    0 0 0 1px rgb(151 174 255 / 22%),
+    0 0 14px rgb(138 162 255 / 18%);
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .minimap-viewport-rect {
+  background: rgb(138 162 255 / 12%);
+  border-color: rgb(226 234 255 / 72%);
+  box-shadow:
+    inset 0 0 0 1px rgb(151 174 255 / 44%),
+    0 0 0 1px rgb(151 174 255 / 22%);
+}
+
 @media (width < 720px) {
   .step-panel {
     max-width: none;
     width: calc(100% - 1rem);
   }
 
-  .step-panel--overlay {
-    bottom: 0.5rem;
+  .canvas-overlay-stack {
     left: 0.5rem;
     right: 0.5rem;
+    bottom: 0.5rem;
   }
 
   .tour-identity {

--- a/packages/web-player/test/diagram-minimap.test.ts
+++ b/packages/web-player/test/diagram-minimap.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDiagramMinimapGeometry,
+  createMinimapCenterScrollPosition,
+  createMinimapViewportScrollPosition,
+  readDiagramMinimapMetrics,
+  readDiagramMinimapNodeRects
+} from "../src/lib/diagram-minimap";
+
+describe("diagram minimap helpers", () => {
+  it("scales the content bounds, viewport rect, and focused nodes into minimap space", () => {
+    expect(
+      createDiagramMinimapGeometry({
+        nodeRects: [
+          { height: 70, left: 180, top: 260, width: 90 },
+          { height: 80, left: 420, top: 260, width: 120 }
+        ],
+        focusedNodeRects: [{ height: 80, left: 420, top: 260, width: 120 }],
+        metrics: createMetrics(),
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      bounds: { height: 160, left: 0, top: 0, width: 197.33 },
+      nodeRects: [
+        { height: 9.33, left: 24, top: 34.67, width: 12 },
+        { height: 10.67, left: 56, top: 34.67, width: 16 }
+      ],
+      focusRects: [{ height: 10.67, left: 56, top: 34.67, width: 16 }],
+      viewportRect: { height: 53.33, left: 20, top: 12, width: 80 }
+    });
+  });
+
+  it("returns null when metrics or minimap size are not stable", () => {
+    expect(
+      createDiagramMinimapGeometry({
+        nodeRects: [{ height: 80, left: 420, top: 260, width: 120 }],
+        focusedNodeRects: [{ height: 80, left: 420, top: 260, width: 120 }],
+        metrics: createMetrics({ contentWidth: 0 }),
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toBeNull();
+
+    expect(
+      createDiagramMinimapGeometry({
+        nodeRects: [{ height: 80, left: 420, top: 260, width: 120 }],
+        focusedNodeRects: [{ height: 80, left: 420, top: 260, width: 120 }],
+        metrics: createMetrics(),
+        minimapSize: { maxHeight: 0, maxWidth: 220 }
+      })
+    ).toBeNull();
+  });
+
+  it("ignores invalid focused rects and clamps oversized viewport positions", () => {
+    expect(
+      createDiagramMinimapGeometry({
+        nodeRects: [{ height: 80, left: 320, top: 260, width: 120 }],
+        focusedNodeRects: [
+          { height: 80, left: Number.NaN, top: 260, width: 120 },
+          { height: 200, left: 1100, top: 800, width: 240 }
+        ],
+        metrics: createMetrics({ scrollLeft: 2000, scrollTop: 1400 }),
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      bounds: { height: 160, left: 0, top: 0, width: 197.33 },
+      nodeRects: [{ height: 10.67, left: 42.67, top: 34.67, width: 16 }],
+      focusRects: [{ height: 26.67, left: 146.67, top: 106.67, width: 32 }],
+      viewportRect: { height: 53.33, left: 117.33, top: 106.67, width: 80 }
+    });
+  });
+
+  it("maps minimap clicks to centered and clamped diagram scroll positions", () => {
+    expect(
+      createMinimapCenterScrollPosition({
+        metrics: createMetrics(),
+        minimapPoint: { x: 98.67, y: 80 },
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      scrollLeft: 440,
+      scrollTop: 400
+    });
+
+    expect(
+      createMinimapCenterScrollPosition({
+        metrics: createMetrics(),
+        minimapPoint: { x: 999, y: 999 },
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      scrollLeft: 880,
+      scrollTop: 800
+    });
+
+    expect(
+      createMinimapCenterScrollPosition({
+        metrics: createMetrics(),
+        minimapPoint: { x: -20, y: -10 },
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      scrollLeft: 0,
+      scrollTop: 0
+    });
+
+    expect(
+      createMinimapCenterScrollPosition({
+        metrics: createMetrics({ viewportHeight: 0 }),
+        minimapPoint: { x: 98.67, y: 80 },
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toBeNull();
+  });
+
+  it("maps dragged viewport origins back into content-space scroll positions", () => {
+    expect(
+      createMinimapViewportScrollPosition({
+        metrics: createMetrics(),
+        minimapSize: { maxHeight: 160, maxWidth: 220 },
+        viewportOrigin: { x: 60, y: 40 }
+      })
+    ).toEqual({
+      scrollLeft: 450,
+      scrollTop: 300
+    });
+
+    expect(
+      createMinimapViewportScrollPosition({
+        metrics: createMetrics(),
+        minimapSize: { maxHeight: 160, maxWidth: 220 },
+        viewportOrigin: { x: 400, y: 400 }
+      })
+    ).toEqual({
+      scrollLeft: 880,
+      scrollTop: 800
+    });
+
+    expect(
+      createMinimapViewportScrollPosition({
+        metrics: createMetrics({ contentHeight: 0 }),
+        minimapSize: { maxHeight: 160, maxWidth: 220 },
+        viewportOrigin: { x: 40, y: 30 }
+      })
+    ).toBeNull();
+  });
+
+  it("clamps negative and oversized minimap rects inside the minimap bounds", () => {
+    expect(
+      createDiagramMinimapGeometry({
+        nodeRects: [
+          { height: 50, left: -40, top: -20, width: -10 },
+          { height: 1600, left: 1300, top: 1100, width: 4000 }
+        ],
+        focusedNodeRects: [
+          { height: 50, left: -40, top: -20, width: -10 },
+          { height: 1600, left: 1300, top: 1100, width: 4000 }
+        ],
+        metrics: createMetrics({ scrollLeft: -100, scrollTop: -120 }),
+        minimapSize: { maxHeight: 160, maxWidth: 220 }
+      })
+    ).toEqual({
+      bounds: { height: 160, left: 0, top: 0, width: 197.33 },
+      nodeRects: [{ height: 160, left: 0, top: 0, width: 197.33 }],
+      focusRects: [{ height: 160, left: 0, top: 0, width: 197.33 }],
+      viewportRect: { height: 53.33, left: 0, top: 0, width: 80 }
+    });
+  });
+
+  it("reads content metrics and focused node rects from the rendered stage", () => {
+    const fixture = createFixture();
+
+    setStageMarkup(
+      fixture,
+      '<div data-node-id="api_gateway"></div><div data-node-id="validation_service"></div>'
+    );
+    mockRect(fixture.content, { height: 1200, left: 40, top: 30, width: 1480 });
+    mockNodeRect(fixture, "api_gateway", { height: 90, left: 420, top: 300, width: 120 });
+    mockNodeRect(fixture, "validation_service", { height: 80, left: 640, top: 420, width: 140 });
+
+    expect(
+      readDiagramMinimapMetrics({
+        container: fixture.container,
+        content: fixture.content
+      })
+    ).toEqual({
+      contentHeight: 1200,
+      contentWidth: 1480,
+      scrollLeft: 150,
+      scrollTop: 90,
+      viewportHeight: 400,
+      viewportWidth: 600
+    });
+
+    expect(
+      readDiagramMinimapNodeRects({
+        content: fixture.content,
+        focusedNodeIds: ["api_gateway", "validation_service", "missing"]
+      })
+    ).toEqual([
+      { height: 90, left: 380, top: 270, width: 120 },
+      { height: 80, left: 600, top: 390, width: 140 }
+    ]);
+  });
+
+  it("falls back to client extents and sanitizes invalid scroll numbers when reading metrics", () => {
+    const fixture = createFixture({
+      clientHeight: 980,
+      clientWidth: 1500,
+      scrollHeight: 0,
+      scrollLeft: Number.NaN,
+      scrollTop: Number.NaN,
+      scrollWidth: 0
+    });
+
+    expect(
+      readDiagramMinimapMetrics({
+        container: fixture.container,
+        content: fixture.content
+      })
+    ).toEqual({
+      contentHeight: 980,
+      contentWidth: 1500,
+      scrollLeft: 0,
+      scrollTop: 0,
+      viewportHeight: 400,
+      viewportWidth: 600
+    });
+  });
+});
+
+function createMetrics(
+  input?: Partial<{
+    contentHeight: number;
+    contentWidth: number;
+    scrollLeft: number;
+    scrollTop: number;
+    viewportHeight: number;
+    viewportWidth: number;
+  }>
+): {
+  contentHeight: number;
+  contentWidth: number;
+  scrollLeft: number;
+  scrollTop: number;
+  viewportHeight: number;
+  viewportWidth: number;
+} {
+  return {
+    contentHeight: readMetric(input, "contentHeight", 1200),
+    contentWidth: readMetric(input, "contentWidth", 1480),
+    scrollLeft: readMetric(input, "scrollLeft", 150),
+    scrollTop: readMetric(input, "scrollTop", 90),
+    viewportHeight: readMetric(input, "viewportHeight", 400),
+    viewportWidth: readMetric(input, "viewportWidth", 600)
+  };
+}
+
+function createFixture(input?: {
+  clientHeight?: number;
+  clientWidth?: number;
+  scrollHeight?: number;
+  scrollLeft?: number;
+  scrollTop?: number;
+  scrollWidth?: number;
+}): {
+  container: HTMLElement;
+  content: HTMLElement;
+} {
+  const nodeMap = new Map<string, Element>();
+  const content = createElementStub({
+    clientHeight: readFixtureValue(input, "clientHeight", 1200),
+    clientWidth: readFixtureValue(input, "clientWidth", 1480),
+    rect: { height: 1200, left: 0, top: 0, width: 1480 },
+    scrollHeight: readFixtureValue(input, "scrollHeight", 1200),
+    scrollWidth: readFixtureValue(input, "scrollWidth", 1480)
+  });
+  const container = createElementStub({
+    clientHeight: 400,
+    clientWidth: 600,
+    rect: { height: 400, left: 0, top: 0, width: 600 },
+    scrollHeight: 400,
+    scrollLeft: readFixtureValue(input, "scrollLeft", 150),
+    scrollTop: readFixtureValue(input, "scrollTop", 90),
+    scrollWidth: 600
+  });
+
+  Object.defineProperty(content, "querySelector", {
+    value: (selector: string) => nodeMap.get(selector) ?? null,
+    writable: true
+  });
+  Object.assign(content, { __nodeMap: nodeMap });
+
+  return {
+    container: container as HTMLElement,
+    content: content as HTMLElement
+  };
+}
+
+function setStageMarkup(
+  fixture: {
+    content: HTMLElement;
+  },
+  markup: string
+): void {
+  const nodeMap = readNodeMap(fixture.content);
+  const matches = [...markup.matchAll(/data-node-id="([^"]+)"/g)];
+
+  nodeMap.clear();
+  matches.forEach((match) => {
+    nodeMap.set(`[data-node-id="${match[1]}"]`, createElementStub());
+  });
+}
+
+function mockNodeRect(
+  fixture: {
+    content: HTMLElement;
+  },
+  nodeId: string,
+  input: RectInput
+): void {
+  mockRect(fixture.content.querySelector(`[data-node-id="${nodeId}"]`) as Element, input);
+}
+
+function mockRect(element: Element, input: RectInput): void {
+  element.getBoundingClientRect = () => createDomRect(input);
+}
+
+function createElementStub(input?: {
+  clientHeight?: number;
+  clientWidth?: number;
+  rect?: RectInput;
+  scrollHeight?: number;
+  scrollLeft?: number;
+  scrollTop?: number;
+  scrollWidth?: number;
+}): Element {
+  return {
+    clientHeight: readElementStubValue(input, "clientHeight", 0),
+    clientWidth: readElementStubValue(input, "clientWidth", 0),
+    getBoundingClientRect: () => createDomRect(readElementRect(input)),
+    querySelector: () => null,
+    scrollHeight: readElementStubValue(input, "scrollHeight", 0),
+    scrollLeft: readElementStubValue(input, "scrollLeft", 0),
+    scrollTop: readElementStubValue(input, "scrollTop", 0),
+    scrollWidth: readElementStubValue(input, "scrollWidth", 0)
+  } as unknown as Element;
+}
+
+function readNodeMap(content: HTMLElement): Map<string, Element> {
+  return (content as HTMLElement & { __nodeMap: Map<string, Element> }).__nodeMap;
+}
+
+function createDomRect(input: RectInput): DOMRect {
+  return {
+    bottom: input.top + input.height,
+    height: input.height,
+    left: input.left,
+    right: input.left + input.width,
+    top: input.top,
+    width: input.width
+  } as DOMRect;
+}
+
+interface RectInput {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
+function readMetric(
+  input: Partial<{
+    contentHeight: number;
+    contentWidth: number;
+    scrollLeft: number;
+    scrollTop: number;
+    viewportHeight: number;
+    viewportWidth: number;
+  }> | undefined,
+  key: "contentHeight" | "contentWidth" | "scrollLeft" | "scrollTop" | "viewportHeight" | "viewportWidth",
+  fallback: number
+): number {
+  return input?.[key] ?? fallback;
+}
+
+function readFixtureValue(
+  input:
+    | {
+        clientHeight?: number;
+        clientWidth?: number;
+        scrollHeight?: number;
+        scrollLeft?: number;
+        scrollTop?: number;
+        scrollWidth?: number;
+      }
+    | undefined,
+  key: "clientHeight" | "clientWidth" | "scrollHeight" | "scrollLeft" | "scrollTop" | "scrollWidth",
+  fallback: number
+): number {
+  return input?.[key] ?? fallback;
+}
+
+function readElementStubValue(
+  input:
+    | {
+        clientHeight?: number;
+        clientWidth?: number;
+        rect?: RectInput;
+        scrollHeight?: number;
+        scrollLeft?: number;
+        scrollTop?: number;
+        scrollWidth?: number;
+      }
+    | undefined,
+  key: "clientHeight" | "clientWidth" | "scrollHeight" | "scrollLeft" | "scrollTop" | "scrollWidth",
+  fallback: number
+): number {
+  return input?.[key] ?? fallback;
+}
+
+function readElementRect(
+  input:
+    | {
+        rect?: RectInput;
+      }
+    | undefined
+): RectInput {
+  return input?.rect ?? { height: 0, left: 0, top: 0, width: 0 };
+}

--- a/packages/web-player/test/tour-player.svelte.test.ts
+++ b/packages/web-player/test/tour-player.svelte.test.ts
@@ -41,6 +41,8 @@ vi.mock("svelte-sonner", () => ({
 describe("tour-player.svelte", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
+    setWindowWidth(1280);
   });
 
   it("renders the selected tour, starts on step one, and respects boundaries", async () => {
@@ -120,6 +122,62 @@ describe("tour-player.svelte", () => {
     expect(diagramShell).not.toBeNull();
     expect(diagramShell?.contains(stepPanel as Node)).toBe(true);
     expect(container.querySelector('[data-testid="tour-identity"]')).not.toBeNull();
+  });
+
+  it("renders the minimap on desktop, shows focused nodes, and stacks it below the step overlay", async () => {
+    const { container } = render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    expect(await screen.findByTestId("minimap-shell")).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("minimap-surface")).toBeDefined();
+      expect(screen.getAllByTestId("minimap-node-marker")).toHaveLength(6);
+      expect(screen.getAllByTestId("minimap-focus-marker")).toHaveLength(1);
+    });
+
+    const overlayStack = container.querySelector('[data-testid="canvas-overlay-stack"]');
+
+    expect(overlayStack?.firstElementChild).toBe(screen.getByTestId("step-overlay"));
+    expect(overlayStack?.lastElementChild).toBe(screen.getByTestId("minimap-shell"));
+  });
+
+  it("hides the minimap automatically on small screens", async () => {
+    setWindowWidth(640);
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    await screen.findByTestId("step-text");
+
+    expect(screen.queryByTestId("minimap-shell")).toBeNull();
+  });
+
+  it("restores the persisted collapsed minimap state and can be reopened", async () => {
+    window.localStorage.setItem("diagram-tour:minimap-collapsed", "true");
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    expect(await screen.findByTestId("minimap-shell")).toBeDefined();
+    expect(screen.queryByTestId("minimap-surface")).toBeNull();
+    expect(screen.getByTestId("minimap-toggle").getAttribute("aria-expanded")).toBe("false");
+
+    await fireEvent.click(screen.getByTestId("minimap-toggle"));
+
+    expect(screen.getByTestId("minimap-toggle").getAttribute("aria-expanded")).toBe("true");
+    await waitFor(() => {
+      expect(screen.getByTestId("minimap-surface")).toBeDefined();
+    });
+    expect(window.localStorage.getItem("diagram-tour:minimap-collapsed")).toBe("false");
   });
 
   it("starts from the deep-linked step and updates the URL when navigating", async () => {
@@ -236,11 +294,59 @@ function renderDiagramForTest(input: {
   container: HTMLElement;
   diagram: typeof resolvedPaymentFlowTour.diagram;
 }): Promise<void> {
-  input.container.innerHTML = input.diagram.nodes
-    .map((node) => `<div data-node-id="${node.id}" data-node-label="${node.label}"></div>`)
-    .join("");
+  const parent = input.container.parentElement as HTMLElement;
+  const positions = createNodePositions();
+
+  input.container.innerHTML = [
+    '<svg data-testid="diagram-svg"></svg>',
+    ...input.diagram.nodes.map(
+      (node) => `<div data-node-id="${node.id}" data-node-label="${node.label}"></div>`
+    )
+  ].join("");
+
+  Object.defineProperties(parent, {
+    clientHeight: { value: 480, writable: true },
+    clientWidth: { value: 720, writable: true },
+    scrollHeight: { value: 480, writable: true },
+    scrollWidth: { value: 720, writable: true }
+  });
+  Object.defineProperties(input.container, {
+    clientHeight: { value: 920, writable: true },
+    clientWidth: { value: 1320, writable: true },
+    scrollHeight: { value: 920, writable: true },
+    scrollWidth: { value: 1320, writable: true }
+  });
+
+  parent.scrollLeft = 0;
+  parent.scrollTop = 0;
+  parent.scrollTo = createScrollToForTest(parent);
+  parent.getBoundingClientRect = () => createDomRect({ height: 480, left: 0, top: 0, width: 720 });
+  input.container.getBoundingClientRect = () =>
+    createDomRect({ height: 920, left: 0, top: 0, width: 1320 });
+
+  const svg = input.container.querySelector("svg") as SVGSVGElement;
+
+  svg.getBoundingClientRect = () => createDomRect({ height: 640, left: 160, top: 140, width: 960 });
+
+  input.container.querySelectorAll<HTMLElement>("[data-node-id]").forEach((element) => {
+    const nodeId = element.dataset.nodeId ?? "";
+    const rect = positions[nodeId];
+
+    element.getBoundingClientRect = () => createDomRect(rect);
+  });
 
   return Promise.resolve();
+}
+
+function createNodePositions(): Record<string, RectInput> {
+  return {
+    api_gateway: { height: 82, left: 360, top: 290, width: 122 },
+    client: { height: 76, left: 150, top: 292, width: 118 },
+    payment_provider: { height: 84, left: 930, top: 290, width: 136 },
+    payment_service: { height: 84, left: 760, top: 290, width: 126 },
+    response: { height: 76, left: 1120, top: 292, width: 128 },
+    validation_service: { height: 84, left: 560, top: 290, width: 142 }
+  };
 }
 
 function applyFocusStateForTest(input: {
@@ -280,4 +386,78 @@ function readFocusState(container: HTMLElement, nodeId: string): string | null {
   return container
     .querySelector(`[data-node-id="${nodeId}"]`)
     ?.getAttribute("data-focus-state") ?? null;
+}
+
+function setWindowWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+    writable: true
+  });
+}
+
+interface RectInput {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}
+
+function createDomRect(input: RectInput): DOMRect {
+  return {
+    bottom: input.top + input.height,
+    height: input.height,
+    left: input.left,
+    right: input.left + input.width,
+    top: input.top,
+    width: input.width
+  } as DOMRect;
+}
+
+function createScrollToForTest(parent: HTMLElement): typeof parent.scrollTo {
+  return ((options: ScrollToOptions | number, top?: number) => {
+    const position = toScrollPositionForTest(parent, options, top);
+
+    parent.scrollLeft = position.scrollLeft;
+    parent.scrollTop = position.scrollTop;
+  }) as typeof parent.scrollTo;
+}
+
+function toScrollPositionForTest(
+  parent: HTMLElement,
+  options: ScrollToOptions | number,
+  top?: number
+): {
+  scrollLeft: number;
+  scrollTop: number;
+} {
+  return typeof options === "number"
+    ? toNumericScrollPositionForTest(options, top)
+    : toObjectScrollPositionForTest(parent, options);
+}
+
+function toNumericScrollPositionForTest(
+  left: number,
+  top?: number
+): {
+  scrollLeft: number;
+  scrollTop: number;
+} {
+  return {
+    scrollLeft: left,
+    scrollTop: top ?? 0
+  };
+}
+
+function toObjectScrollPositionForTest(
+  parent: HTMLElement,
+  options: ScrollToOptions
+): {
+  scrollLeft: number;
+  scrollTop: number;
+} {
+  return {
+    scrollLeft: options.left ?? parent.scrollLeft,
+    scrollTop: options.top ?? parent.scrollTop
+  };
 }


### PR DESCRIPTION
## Summary
- add a desktop-first navigation minimap with click-to-pan and viewport dragging
- render simplified diagram context plus focused nodes in the minimap
- add minimap unit, component, and smoke coverage and update repo docs

## Checks
- bun run lint
- bun run typecheck
- bun run test
- bun run smoke
- bun run build