### PR TITLE
Add stronger lint guardrails

### DIFF
--- a/DELIVERY_CHECKLIST.MD
+++ b/DELIVERY_CHECKLIST.MD
@@ -36,7 +36,10 @@ Code must not be delivered if any guardrail is broken:
 - coverage drops below `100%` for statements, branches, functions, or lines
 - typecheck fails
 - configured complexity rules fail
+- configured nesting-depth rules fail
+- configured function-length rules fail
 - configured function arity rules fail
+- configured async/exhaustiveness guardrails fail
 - documented contracts are changed without corresponding documentation updates
 
 ## Owner Verification Readiness

--- a/ENGINEERING_PLAYBOOK.MD
+++ b/ENGINEERING_PLAYBOOK.MD
@@ -64,8 +64,13 @@ The repository enforces strong guardrails and they are part of normal developmen
 - lint rules must pass
 - test coverage must remain at `100%` for statements, branches, functions, and lines
 - cyclomatic complexity must remain at or below `3`
+- block nesting depth must remain at or below `3`
+- function bodies should stay at or below `30` lines unless a narrower exception is explicitly justified
 - function arity must remain at or below `3`
 - if more inputs are required, prefer an object parameter
+- floating promises are not allowed
+- unnecessary conditional guards are not allowed
+- discriminated unions and similar switches must remain exhaustive
 - type checks must pass
 - the final relevant test suite must pass
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import svelteConfig from "./packages/web-player/svelte.config.js";
 
 const sharedRules = {
   complexity: ["error", 3],
+  "max-depth": ["error", 3],
   "max-params": ["error", 3],
   curly: ["error", "all"],
   eqeqeq: ["error", "always"],
@@ -30,7 +31,14 @@ const sharedRules = {
       varsIgnorePattern: "^_",
       caughtErrorsIgnorePattern: "^_"
     }
-  ]
+  ],
+};
+
+const typedGuardrailRules = {
+  "max-lines-per-function": ["error", 30],
+  "@typescript-eslint/no-floating-promises": "error",
+  "@typescript-eslint/no-unnecessary-condition": "error",
+  "@typescript-eslint/switch-exhaustiveness-check": "error"
 };
 
 export default defineConfig([
@@ -67,8 +75,11 @@ export default defineConfig([
     languageOptions: {
       parser: svelteParser,
       parserOptions: {
+        extraFileExtensions: [".svelte"],
         parser: tseslint.parser,
-        svelteConfig
+        projectService: true,
+        svelteConfig,
+        tsconfigRootDir: import.meta.dirname
       },
       globals: {
         ...globals.browser
@@ -79,12 +90,23 @@ export default defineConfig([
     }
   },
   {
-    files: ["packages/web-player/src/**/*.ts", "packages/web-player/vite.config.ts"],
+    files: [
+      "packages/*/src/**/*.ts",
+      "packages/web-player/src/**/*.svelte",
+      "scripts/**/*.ts"
+    ],
     languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      },
       globals: {
         ...globals.browser,
         ...globals.node
       }
+    },
+    rules: {
+      ...typedGuardrailRules
     }
   }
 ]);

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -26,32 +26,20 @@ export async function loadResolvedTour(tourPath: string): Promise<ResolvedDiagra
   const context = createTourContext(absoluteTourPath);
 
   return runWithContext(context, async () => {
-    const tourSource = await readTextFile(absoluteTourPath);
-    const rawTour = parseTourDocument({
-      source: tourSource,
+    const rawTour = await readRawTourDocument({
+      absoluteTourPath,
       context
     });
-    const absoluteDiagramPath = resolve(dirname(absoluteTourPath), rawTour.diagram);
-    const diagramSource = await readTextFile(absoluteDiagramPath);
-    const nodeIndex = createNodeIndex(diagramSource);
+    const diagramSource = await readDiagramSource({
+      absoluteTourPath,
+      diagramPath: rawTour.diagram
+    });
 
-    return {
-      version: rawTour.version,
-      title: rawTour.title,
-      diagram: {
-        path: normalizePath(rawTour.diagram),
-        source: diagramSource,
-        nodes: Array.from(nodeIndex.values())
-      },
-      steps: rawTour.steps.map((step, index) =>
-        resolveTourStep({
-          step,
-          stepIndex: index + 1,
-          nodeIndex,
-          context
-        })
-      )
-    };
+    return resolveLoadedTour({
+      context,
+      diagramSource,
+      rawTour
+    });
   });
 }
 
@@ -86,34 +74,22 @@ async function createDiscoveredTourCollection(
   sourceRoot: string
 ): Promise<ResolvedDiagramTourCollection> {
   const tourPaths = await collectTourPaths(sourceRoot);
-  const entries: ResolvedDiagramTourCollectionEntry[] = [];
-  const skipped: SkippedResolvedDiagramTour[] = [];
+  const result = createDiscoveredCollectionResult();
 
   for (const absoluteTourPath of tourPaths) {
-    try {
-      entries.push(
-        await createCollectionEntry({
-          absoluteTourPath,
-          sourceRoot
-        })
-      );
-    } catch (error) {
-      skipped.push({
-        sourcePath: normalizePath(relative(sourceRoot, absoluteTourPath)),
-        error: (error as Error).message
-      });
-    }
+    await appendDiscoveredTourResult({
+      absoluteTourPath,
+      result,
+      sourceRoot
+    });
   }
 
   invariant(
-    entries.length > 0,
+    result.entries.length > 0,
     `${NO_VALID_TOURS_MESSAGE} in source target "${normalizePath(sourceRoot)}".`
   );
 
-  return {
-    entries,
-    skipped
-  };
+  return result;
 }
 
 async function createCollectionEntry(input: {
@@ -152,10 +128,63 @@ function collectTourFilePath(sourceRoot: string, name: string): string[] {
   return [resolve(sourceRoot, name)];
 }
 
+function createDiscoveredCollectionResult(): {
+  entries: ResolvedDiagramTourCollectionEntry[];
+  skipped: SkippedResolvedDiagramTour[];
+} {
+  return {
+    entries: [],
+    skipped: []
+  };
+}
+
+async function appendDiscoveredTourResult(input: {
+  absoluteTourPath: string;
+  result: {
+    entries: ResolvedDiagramTourCollectionEntry[];
+    skipped: SkippedResolvedDiagramTour[];
+  };
+  sourceRoot: string;
+}): Promise<void> {
+  try {
+    input.result.entries.push(
+      await createCollectionEntry({
+        absoluteTourPath: input.absoluteTourPath,
+        sourceRoot: input.sourceRoot
+      })
+    );
+  } catch (error) {
+    input.result.skipped.push(createSkippedTourEntry(input.absoluteTourPath, input.sourceRoot, error));
+  }
+}
+
+function createSkippedTourEntry(
+  absoluteTourPath: string,
+  sourceRoot: string,
+  error: unknown
+): SkippedResolvedDiagramTour {
+  return {
+    sourcePath: normalizePath(relative(sourceRoot, absoluteTourPath)),
+    error: (error as Error).message
+  };
+}
+
 async function readTextFile(path: string): Promise<string> {
   const source = await readFile(path, "utf8");
 
   return normalizeNewlines(source);
+}
+
+async function readRawTourDocument(input: {
+  absoluteTourPath: string;
+  context: TourContext;
+}): Promise<DiagramTour> {
+  const tourSource = await readTextFile(input.absoluteTourPath);
+
+  return parseTourDocument({
+    source: tourSource,
+    context: input.context
+  });
 }
 
 function parseTourDocument(input: { source: string; context: TourContext }): DiagramTour {
@@ -175,22 +204,64 @@ function createTourContext(sourcePath: string): TourContext {
   };
 }
 
+async function readDiagramSource(input: {
+  absoluteTourPath: string;
+  diagramPath: string;
+}): Promise<string> {
+  const absoluteDiagramPath = resolve(dirname(input.absoluteTourPath), input.diagramPath);
+
+  return readTextFile(absoluteDiagramPath);
+}
+
+function resolveLoadedTour(input: {
+  context: TourContext;
+  diagramSource: string;
+  rawTour: DiagramTour;
+}): ResolvedDiagramTour {
+  const nodeIndex = createNodeIndex(input.diagramSource);
+
+  return {
+    version: input.rawTour.version,
+    title: input.rawTour.title,
+    diagram: createResolvedDiagram(input.rawTour.diagram, input.diagramSource, nodeIndex),
+    steps: resolveLoadedTourSteps(input.rawTour.steps, nodeIndex, input.context)
+  };
+}
+
+function createResolvedDiagram(
+  diagramPath: string,
+  diagramSource: string,
+  nodeIndex: NodeIndex
+): ResolvedDiagramTour["diagram"] {
+  return {
+    path: normalizePath(diagramPath),
+    source: diagramSource,
+    nodes: Array.from(nodeIndex.values())
+  };
+}
+
+function resolveLoadedTourSteps(
+  steps: TourStep[],
+  nodeIndex: NodeIndex,
+  context: TourContext
+): ResolvedDiagramTour["steps"] {
+  return steps.map((step, index) =>
+    resolveTourStep({
+      step,
+      stepIndex: index + 1,
+      nodeIndex,
+      context
+    })
+  );
+}
+
 function toDiagramTour(input: { value: unknown; context: TourContext }): DiagramTour {
   invariant(isRecord(input.value), createTourMessage(input.context, "document must be an object"));
 
   const version = input.value.version;
-  const title = asNonEmptyString(
-    input.value.title,
-    createTourMessage(input.context, "title is required")
-  );
-  const diagram = asNonEmptyString(
-    input.value.diagram,
-    createTourMessage(input.context, "diagram path is required")
-  );
-  const steps = asNonEmptyArray(
-    input.value.steps,
-    createTourMessage(input.context, "steps must be a non-empty array")
-  );
+  const title = readTourTitle(input.value, input.context);
+  const diagram = readTourDiagramPath(input.value, input.context);
+  const steps = readTourSteps(input.value, input.context);
 
   invariant(
     version === SUPPORTED_TOUR_VERSION,
@@ -209,6 +280,21 @@ function toDiagramTour(input: { value: unknown; context: TourContext }): Diagram
       })
     )
   };
+}
+
+function readTourTitle(value: Record<string, unknown>, context: TourContext): string {
+  return asNonEmptyString(value.title, createTourMessage(context, "title is required"));
+}
+
+function readTourDiagramPath(value: Record<string, unknown>, context: TourContext): string {
+  return asNonEmptyString(value.diagram, createTourMessage(context, "diagram path is required"));
+}
+
+function readTourSteps(value: Record<string, unknown>, context: TourContext): unknown[] {
+  return asNonEmptyArray(
+    value.steps,
+    createTourMessage(context, "steps must be a non-empty array")
+  );
 }
 
 function toTourStep(input: {

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -33,6 +33,24 @@
     maxWidth: 220
   } as const;
 
+  type ViewportDragState = {
+    didDrag: boolean;
+    offsetX: number;
+    offsetY: number;
+    pointerId: number;
+  };
+
+  type ViewportOrigin = {
+    x: number;
+    y: number;
+  };
+
+  type ViewportDragInput = {
+    dragState: ViewportDragState;
+    metrics: DiagramMinimapMetrics;
+    viewportOrigin: ViewportOrigin;
+  };
+
   export let initialStepIndex: number;
   export let selectedSlug: string;
   export let tour: ResolvedDiagramTour;
@@ -51,14 +69,7 @@
   let isMinimapCollapsed = false;
   let minimapGeometry: DiagramMinimapGeometry | null = null;
   let previousInitialStepIndex = initialStepIndex;
-  let viewportDragState:
-    | {
-        didDrag: boolean;
-        offsetX: number;
-        offsetY: number;
-        pointerId: number;
-      }
-    | null = null;
+  let viewportDragState: ViewportDragState | null = null;
 
   async function goPrevious(): Promise<void> {
     state = player.goPrevious();
@@ -418,14 +429,7 @@
         });
   }
 
-  function readViewportDragState(event: PointerEvent):
-    | {
-        didDrag: boolean;
-        offsetX: number;
-        offsetY: number;
-        pointerId: number;
-      }
-    | null {
+  function readViewportDragState(event: PointerEvent): ViewportDragState | null {
     const viewportRect = event.currentTarget;
 
     if (minimapGeometry === null || !(viewportRect instanceof HTMLElement)) {
@@ -452,47 +456,18 @@
     return viewportDragState !== null && event.pointerId === viewportDragState.pointerId;
   }
 
-  function readCurrentViewportDragState(event: PointerEvent):
-    | {
-        didDrag: boolean;
-        offsetX: number;
-        offsetY: number;
-        pointerId: number;
-      }
-    | null {
+  function readCurrentViewportDragState(event: PointerEvent): ViewportDragState | null {
     return matchesViewportDragPointer(event) ? viewportDragState : null;
   }
 
-  function markViewportDragStateAsDragged(input: {
-    didDrag: boolean;
-    offsetX: number;
-    offsetY: number;
-    pointerId: number;
-  }): {
-    didDrag: boolean;
-    offsetX: number;
-    offsetY: number;
-    pointerId: number;
-  } {
+  function markViewportDragStateAsDragged(input: ViewportDragState): ViewportDragState {
     return {
       ...input,
       didDrag: true
     };
   }
 
-  function readViewportDragInput(event: PointerEvent): {
-    dragState: {
-      didDrag: boolean;
-      offsetX: number;
-      offsetY: number;
-      pointerId: number;
-    };
-    metrics: DiagramMinimapMetrics;
-    viewportOrigin: {
-      x: number;
-      y: number;
-    };
-  } | null {
+  function readViewportDragInput(event: PointerEvent): ViewportDragInput | null {
     const dragState = readCurrentViewportDragState(event);
     const metrics = readCurrentMinimapMetrics();
     const viewportOrigin = readDraggedViewportOrigin(event);
@@ -509,64 +484,26 @@
   }
 
   function hasMissingViewportDragInput(
-    dragState: {
-      didDrag: boolean;
-      offsetX: number;
-      offsetY: number;
-      pointerId: number;
-    } | null,
+    dragState: ViewportDragState | null,
     metrics: DiagramMinimapMetrics | null,
-    viewportOrigin: {
-      x: number;
-      y: number;
-    } | null
+    viewportOrigin: ViewportOrigin | null
   ): boolean {
     return [dragState, metrics, viewportOrigin].some((value) => value === null);
   }
 
   function createViewportDragInputPayload(input: {
-    dragState: {
-      didDrag: boolean;
-      offsetX: number;
-      offsetY: number;
-      pointerId: number;
-    } | null;
+    dragState: ViewportDragState | null;
     metrics: DiagramMinimapMetrics | null;
-    viewportOrigin:
-      | {
-          x: number;
-          y: number;
-        }
-      | null;
-  }): {
-    dragState: {
-      didDrag: boolean;
-      offsetX: number;
-      offsetY: number;
-      pointerId: number;
-    };
-    metrics: DiagramMinimapMetrics;
-    viewportOrigin: {
-      x: number;
-      y: number;
-    };
-  } {
+    viewportOrigin: ViewportOrigin | null;
+  }): ViewportDragInput {
     return {
-      dragState: input.dragState as {
-        didDrag: boolean;
-        offsetX: number;
-        offsetY: number;
-        pointerId: number;
-      },
+      dragState: input.dragState as ViewportDragState,
       metrics: input.metrics as DiagramMinimapMetrics,
-      viewportOrigin: input.viewportOrigin as {
-        x: number;
-        y: number;
-      }
+      viewportOrigin: input.viewportOrigin as ViewportOrigin
     };
   }
 
-  function readDraggedViewportOrigin(event: PointerEvent): { x: number; y: number } | null {
+  function readDraggedViewportOrigin(event: PointerEvent): ViewportOrigin | null {
     const minimapPoint = readMinimapPoint(event);
 
     if (minimapPoint === null || viewportDragState === null) {

--- a/packages/web-player/src/routes/+error.svelte
+++ b/packages/web-player/src/routes/+error.svelte
@@ -34,7 +34,7 @@
     <div class="controls error-actions">
       <a
         class="button error-actions__button error-actions__button--primary"
-        href={resolve(fallbackTour === undefined ? "/" : `/${fallbackTour.slug}`)}
+        href={resolve(`/${fallbackTour.slug}`)}
       >
         Back to Tours
       </a>


### PR DESCRIPTION
## Summary
- add stricter lint guardrails for function depth, size, async handling, and exhaustiveness
- refactor parser and player code to satisfy the new constraints cleanly
- document the expanded guardrails in the engineering docs

## Checks
- bun run lint
- bun run typecheck
- bun run test
- bun run smoke
- bun run build
