### PR TITLE
Fix arrow keys to respect active overlay interaction context

### DIFF
--- a/packages/web-player/smoke/checkout-decision.docs-shell-browse-navigation.spec.ts
+++ b/packages/web-player/smoke/checkout-decision.docs-shell-browse-navigation.spec.ts
@@ -15,6 +15,15 @@ test("docs shell browse navigation changes tours without breaking the player", a
   await expect(page.getByTestId("browse-search-input")).toBeVisible();
   await expect(page.getByTestId("browse-tour-row").first()).toBeVisible();
   await expect(page.getByTestId("step-text-container")).toContainText("human or audited service");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowLeft");
+  await expect(page).toHaveURL(/\/checkout-decision-flow\?step=3$/);
+  await expect(page.getByTestId("step-text-container")).toContainText("human or audited service");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("browse-panel")).toBeHidden();
+  await page.keyboard.press("ArrowRight");
+  await expect(page).toHaveURL(/\/checkout-decision-flow\?step=4$/);
+  await page.keyboard.press("ArrowLeft");
   await expectDiagramVisible(page);
   await expect(page).toHaveURL(/\/checkout-decision-flow\?step=3$/);
   await expect(page.locator('[data-testid="diagram-container"] [data-node-id="review"]')).toHaveCount(1);
@@ -23,6 +32,8 @@ test("docs shell browse navigation changes tours without breaking the player", a
     page.locator('[data-testid="diagram-container"][data-focus-group-mode="group"][data-focus-group-size="2"]')
   ).toHaveCount(1);
 
+  await page.getByTestId("search-hint-trigger").click();
+  await expect(page.getByTestId("browse-panel")).toBeVisible();
   await page.getByTestId("browse-search-input").fill("refund");
   await expect(page.getByText("Refund Flow")).toBeVisible();
   await page.getByText("Refund Flow").click();

--- a/packages/web-player/smoke/parallel-onboarding.diagnostics-hierarchy.spec.ts
+++ b/packages/web-player/smoke/parallel-onboarding.diagnostics-hierarchy.spec.ts
@@ -3,6 +3,7 @@ import { startDevServer } from "./dev-server";
 
 test("issues popover presents a readable diagnostics hierarchy", async ({ page }) => {
   test.slow();
+  const docsSlug = "docs/authoring-guide/start-with-stable-mermaid-ids";
 
   const server = await startDevServer({
     port: 4181,
@@ -10,8 +11,9 @@ test("issues popover presents a readable diagnostics hierarchy", async ({ page }
   });
 
   try {
-    await page.goto(`${server.baseUrl}/parallel-onboarding`);
+    await page.goto(`${server.baseUrl}/${docsSlug}?step=1`);
     await expect(page.getByTestId("theme-root")).toHaveAttribute("data-hydrated", "true");
+    await expect(page).toHaveURL(new RegExp(`/${docsSlug.replaceAll("/", "\\/")}\\?step=1$`));
 
     await expect(page.getByTestId("diagnostics-trigger")).toBeVisible();
     await page.getByTestId("diagnostics-trigger").evaluate((element) => {
@@ -21,6 +23,24 @@ test("issues popover presents a readable diagnostics hierarchy", async ({ page }
     await expect(page.getByTestId("diagnostics-panel")).toBeVisible();
     await expect(page.getByTestId("diagnostics-item").first()).toContainText(".tour.yaml");
     await expect(page.getByTestId("diagnostics-item").first()).toContainText("unknown Mermaid node id");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowLeft");
+    await expect(page).toHaveURL(new RegExp(`/${docsSlug.replaceAll("/", "\\/")}\\?step=1$`));
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("diagnostics-panel")).toBeHidden();
+    await expect(page.getByTestId("theme-root")).toHaveAttribute(
+      "data-active-interaction-context",
+      "diagram"
+    );
+
+    const canGoNext = await page.getByTestId("next-button").isEnabled();
+
+    if (canGoNext) {
+      await page.keyboard.press("ArrowRight");
+      await expect(page).toHaveURL(new RegExp(`/${docsSlug.replaceAll("/", "\\/")}\\?step=2$`));
+    } else {
+      await expect(page.getByTestId("next-button")).toBeDisabled();
+    }
   } finally {
     await server.stop();
   }

--- a/packages/web-player/src/lib/interaction-context.ts
+++ b/packages/web-player/src/lib/interaction-context.ts
@@ -1,0 +1,35 @@
+export type ActiveInteractionContext = "diagram" | "browse" | "diagnostics";
+
+export const ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE = "data-active-interaction-context";
+
+export function readActiveInteractionContext(input: {
+  isBrowseOpen: boolean;
+  isDiagnosticsOpen: boolean;
+}): ActiveInteractionContext {
+  if (input.isBrowseOpen) {
+    return "browse";
+  }
+
+  if (input.isDiagnosticsOpen) {
+    return "diagnostics";
+  }
+
+  return "diagram";
+}
+
+export function readActiveInteractionContextFromDocument(
+  documentValue: Document
+): ActiveInteractionContext {
+  const marker = documentValue.querySelector<HTMLElement>(
+    `[${ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE}]`
+  );
+  const contextValue = marker?.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE);
+
+  return isActiveInteractionContext(contextValue) ? contextValue : "diagram";
+}
+
+function isActiveInteractionContext(
+  value: string | null | undefined
+): value is ActiveInteractionContext {
+  return value === "diagram" || value === "browse" || value === "diagnostics";
+}

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -34,6 +34,7 @@
   } from "$lib/diagram-minimap";
   import { createOverviewScrollPosition, focusDiagramViewport } from "$lib/diagram-viewport";
   import { createFocusGroup, type FocusGroup } from "$lib/focus-group";
+  import { readActiveInteractionContextFromDocument } from "$lib/interaction-context";
   import { createTourPlayer } from "$lib/player-state";
   import {
     createNodeStepChoices,
@@ -1016,7 +1017,19 @@
   }
 
   function shouldIgnoreKeyboardNavigation(event: KeyboardEvent): boolean {
-    return event.defaultPrevented || hasNavigationModifierKeys(event) || isTypingTarget(event.target);
+    if (hasKeyboardNavigationBlocker(event)) {
+      return true;
+    }
+
+    return readActiveInteractionContextFromDocument(document) !== "diagram";
+  }
+
+  function hasKeyboardNavigationBlocker(event: KeyboardEvent): boolean {
+    return [
+      event.defaultPrevented,
+      hasNavigationModifierKeys(event),
+      isTypingTarget(event.target)
+    ].some(Boolean);
   }
 
   function hasNavigationModifierKeys(event: KeyboardEvent): boolean {

--- a/packages/web-player/src/routes/+layout.svelte
+++ b/packages/web-player/src/routes/+layout.svelte
@@ -25,6 +25,11 @@
     countDiagnosticIssues,
     createDiagnosticDisplayGroups
   } from "$lib/diagnostics";
+  import {
+    readActiveInteractionContext,
+    type ActiveInteractionContext,
+    ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE
+  } from "$lib/interaction-context";
   import type { SourceTargetInfo } from "$lib/source-target";
   import {
     DEFAULT_THEME,
@@ -69,6 +74,7 @@
   let diagnosticIssueCount = countDiagnosticIssues(diagnosticGroups);
   let isHydrated = false;
   let breadcrumbs = ["diagram-tours", "collection"];
+  let activeInteractionContext: ActiveInteractionContext = "diagram";
 
   $: {
     activeSlug = readActiveSlug(page.url.pathname);
@@ -88,6 +94,10 @@
       items: browseItems
     });
     breadcrumbs = readBreadcrumbs(activeEntry);
+    activeInteractionContext = readActiveInteractionContext({
+      isBrowseOpen,
+      isDiagnosticsOpen
+    });
   }
 
   function handleThemeToggle(): void {
@@ -421,7 +431,13 @@
 
 <svelte:window on:keydown={handleWindowKeydown} on:resize={handleWindowResize} />
 
-<div class="theme-root" data-theme={theme} data-hydrated={isHydrated} data-testid="theme-root">
+<div
+  class="theme-root"
+  data-theme={theme}
+  data-hydrated={isHydrated}
+  data-testid="theme-root"
+  {...{ [ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE]: activeInteractionContext }}
+>
   <Toaster richColors position="bottom-right" />
 
   <div class="app-shell">

--- a/packages/web-player/test/interaction-context.test.ts
+++ b/packages/web-player/test/interaction-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE,
+  readActiveInteractionContext,
+  readActiveInteractionContextFromDocument
+} from "../src/lib/interaction-context";
+
+describe("interaction-context", () => {
+  it("returns diagram when no overlays are open", () => {
+    expect(readActiveInteractionContext({ isBrowseOpen: false, isDiagnosticsOpen: false })).toBe(
+      "diagram"
+    );
+  });
+
+  it("returns browse when browse is open", () => {
+    expect(readActiveInteractionContext({ isBrowseOpen: true, isDiagnosticsOpen: false })).toBe(
+      "browse"
+    );
+  });
+
+  it("returns diagnostics when issues are open", () => {
+    expect(readActiveInteractionContext({ isBrowseOpen: false, isDiagnosticsOpen: true })).toBe(
+      "diagnostics"
+    );
+  });
+
+  it("prioritizes browse when both overlays are open", () => {
+    expect(readActiveInteractionContext({ isBrowseOpen: true, isDiagnosticsOpen: true })).toBe(
+      "browse"
+    );
+  });
+
+  it("reads context from the root marker", () => {
+    document.body.innerHTML = `<div ${ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE}="diagnostics"></div>`;
+
+    expect(readActiveInteractionContextFromDocument(document)).toBe("diagnostics");
+  });
+
+  it("falls back to diagram when the root marker is missing", () => {
+    document.body.innerHTML = "<div></div>";
+
+    expect(readActiveInteractionContextFromDocument(document)).toBe("diagram");
+  });
+});

--- a/packages/web-player/test/layout.svelte.test.ts
+++ b/packages/web-player/test/layout.svelte.test.ts
@@ -20,6 +20,7 @@ import Layout from "../src/routes/+layout.svelte";
 import {
   FAVORITES_STORAGE_KEY
 } from "../src/lib/browse-favorites";
+import { ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE } from "../src/lib/interaction-context";
 import { RECENT_STORAGE_KEY } from "../src/lib/browse-recents";
 import {
   nestedTourCollection,
@@ -228,6 +229,30 @@ describe("+layout.svelte", () => {
     await new Promise((resolve) => setTimeout(resolve, 160));
     await fireEvent.click(screen.getByTestId("browse-backdrop"));
     expect(screen.queryByTestId("browse-panel")).toBeNull();
+  });
+
+  it("publishes active interaction context across overlay transitions", async () => {
+    render(Layout, {
+      data: {
+        collection: resolvedTourCollection,
+        sourceTarget: directorySourceTarget
+      }
+    });
+
+    const themeRoot = screen.getByTestId("theme-root");
+    expect(themeRoot.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE)).toBe("diagram");
+
+    await fireEvent.click(screen.getByTestId("search-hint-trigger"));
+    expect(themeRoot.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE)).toBe("browse");
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    expect(themeRoot.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE)).toBe("diagram");
+
+    await fireEvent.click(screen.getByTestId("diagnostics-trigger"));
+    expect(themeRoot.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE)).toBe("diagnostics");
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    expect(themeRoot.getAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE)).toBe("diagram");
   });
 
   it("keeps the command palette open when reopened after a route change settles", async () => {

--- a/packages/web-player/test/tour-player.svelte.test.ts
+++ b/packages/web-player/test/tour-player.svelte.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE } from "../src/lib/interaction-context";
 import TourPlayer from "../src/lib/tour-player.svelte";
 import { resolvedPaymentFlowTour } from "./fixtures/resolved-tour";
 
@@ -47,6 +48,7 @@ describe("tour-player.svelte", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.clear();
+    document.documentElement.removeAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE);
     setWindowWidth(1280);
     mockElementAnimate();
   });
@@ -341,6 +343,76 @@ describe("tour-player.svelte", () => {
         invalidateAll: false,
         keepFocus: true,
         noScroll: true,
+      });
+    });
+  });
+
+  it("allows arrow navigation when diagram is the active interaction context", async () => {
+    document.documentElement.setAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE, "diagram");
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    await screen.findByTestId("step-text");
+    await fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(gotoMock).toHaveBeenLastCalledWith("/payment-flow?step=2", {
+        invalidateAll: false,
+        keepFocus: true,
+        noScroll: true
+      });
+    });
+  });
+
+  it("blocks arrow navigation when browse is the active interaction context", async () => {
+    document.documentElement.setAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE, "browse");
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    await screen.findByTestId("step-text");
+    await fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    expect(gotoMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks arrow navigation when diagnostics is the active interaction context", async () => {
+    document.documentElement.setAttribute(ACTIVE_INTERACTION_CONTEXT_ATTRIBUTE, "diagnostics");
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    await screen.findByTestId("step-text");
+    await fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    expect(gotoMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to diagram behavior when context marker is missing", async () => {
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour
+    });
+
+    await screen.findByTestId("step-text");
+    await fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(gotoMock).toHaveBeenLastCalledWith("/payment-flow?step=2", {
+        invalidateAll: false,
+        keepFocus: true,
+        noScroll: true
       });
     });
   });


### PR DESCRIPTION
## Summary
- add a shared `interaction-context` contract in `web-player`
- expose active keyboard context on layout root via `data-active-interaction-context`
- gate TourPlayer left/right arrow navigation to run only when context is `diagram`
- keep Browse keyboard behavior (`ArrowUp/ArrowDown/Enter`) unchanged, and keep Issues without arrow navigation

## Tests
- targeted unit/integration tests:
  - `packages/web-player/test/interaction-context.test.ts`
  - `packages/web-player/test/layout.svelte.test.ts`
  - `packages/web-player/test/tour-player.svelte.test.ts`
- targeted smoke specs:
  - `packages/web-player/smoke/checkout-decision.docs-shell-browse-navigation.spec.ts`
  - `packages/web-player/smoke/parallel-onboarding.diagnostics-hierarchy.spec.ts`
- `packages/web-player` typecheck

## Scope notes
- no changes to CLI/parser/core contracts
- no visual redesign of overlays
- behavior scope limited to arrow-key consistency by active context