### PR TITLE
Improve web player zoom and tour navigation

### DIFF
--- a/packages/web-player/smoke/checkout-decision.docs-shell-browse-navigation.spec.ts
+++ b/packages/web-player/smoke/checkout-decision.docs-shell-browse-navigation.spec.ts
@@ -28,6 +28,7 @@ test("docs shell browse navigation changes tours without breaking the player", a
   await page.getByText("Refund Flow").click();
 
   await expect(page).toHaveURL(/\/checkout-refund-flow$/);
+  await expect(page.getByTestId("topbar-breadcrumbs")).toContainText("Refund Flow");
   await expect(page.getByTestId("step-text-container")).toContainText("reverse a payment");
 
   await page.getByTestId("search-hint-trigger").click();
@@ -39,5 +40,6 @@ test("docs shell browse navigation changes tours without breaking the player", a
   await page.getByText("Decision Flow").click();
 
   await expect(page).toHaveURL(/\/checkout-decision-flow$/);
+  await expect(page.getByTestId("topbar-breadcrumbs")).toContainText("Decision Flow");
   await expect(page.getByTestId("step-text")).toBeVisible();
 });

--- a/packages/web-player/smoke/checkout-payment.zoom-controls.spec.ts
+++ b/packages/web-player/smoke/checkout-payment.zoom-controls.spec.ts
@@ -1,24 +1,60 @@
 import { expect, test } from "@playwright/test";
-import { expectCameraPanelToContainControls, expectDiagramVisible, readNodeAxisSize } from "./smoke-test-helpers";
+import {
+  expectCameraPanelToContainControls,
+  expectDiagramVisible,
+  readDiagramScrollPosition,
+  readNodeAxisSize
+} from "./smoke-test-helpers";
 
 test("zoom controls resize the active diagram and return cleanly", async ({ page }) => {
   await page.goto("/checkout-payment-flow");
   await expectDiagramVisible(page);
   await expectCameraPanelToContainControls(page);
+  await expect(page.getByTestId("zoom-out-button")).toBeVisible();
+  await expect(page.getByTestId("zoom-fit-button")).toBeVisible();
+  await expect(page.getByTestId("zoom-one-hundred-button")).toBeVisible();
+  await expect(page.getByTestId("zoom-in-button")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.getByTestId("viewport-toolbar").evaluate((element) =>
+        Array.from(element.children).map((child) => child.getAttribute("data-testid") ?? child.textContent?.trim())
+      )
+    )
+    .toEqual(["zoom-primary-controls", "zoom-value", "zoom-one-hundred-button"]);
 
   const baselineWidth = await readNodeAxisSize(page, "api_gateway", "width");
+
+  await page.getByTestId("zoom-fit-button").click();
+  await page.waitForTimeout(250);
+
+  const fittedWidth = await readNodeAxisSize(page, "api_gateway", "width");
+  const fittedScroll = await readDiagramScrollPosition(page);
 
   await page.getByTestId("zoom-in-button").click();
 
   await expect.poll(async () => readNodeAxisSize(page, "api_gateway", "width")).toBeGreaterThan(
-    baselineWidth * 1.15
+    fittedWidth * 1.1
   );
-  await expect(page.getByTestId("zoom-value")).toContainText("125%");
+
+  await page.getByTestId("zoom-fit-button").click();
+  await page.waitForTimeout(250);
+
+  await expect.poll(async () => readNodeAxisSize(page, "api_gateway", "width")).toBeCloseTo(
+    fittedWidth,
+    0
+  );
+  await expect.poll(() => readDiagramScrollPosition(page)).toEqual(fittedScroll);
 
   await page.getByTestId("zoom-out-button").click();
-
   await expect.poll(async () => readNodeAxisSize(page, "api_gateway", "width")).toBeLessThan(
-    baselineWidth * 1.05
+    baselineWidth * 0.95
+  );
+
+  await page.getByTestId("zoom-one-hundred-button").click();
+  await page.waitForTimeout(250);
+
+  await expect.poll(async () => readNodeAxisSize(page, "api_gateway", "width")).toBeGreaterThan(
+    baselineWidth * 0.95
   );
   await expect(page.getByTestId("zoom-value")).toContainText("100%");
 });

--- a/packages/web-player/smoke/ops-huge-system.minimap-drag-pans-viewport.spec.ts
+++ b/packages/web-player/smoke/ops-huge-system.minimap-drag-pans-viewport.spec.ts
@@ -1,10 +1,17 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { expectDiagramVisible, readDiagramScrollPosition } from "./smoke-test-helpers";
 
 test("dragging the minimap viewport rectangle pans the main diagram viewport", async ({ page }) => {
   await page.goto("/ops-huge-system");
   await expectDiagramVisible(page);
   await expect(page.getByTestId("minimap-viewport-rect")).toBeVisible();
+  await expectMinimapEdgesToStayInsideSurface(page);
+
+  await page.getByTestId("zoom-fit-button").click();
+  await expectMinimapEdgesToStayInsideSurface(page);
+
+  await page.getByTestId("zoom-in-button").click();
+  await expectMinimapEdgesToStayInsideSurface(page);
 
   const previousScroll = await readDiagramScrollPosition(page);
   const viewportRectBox = await page.getByTestId("minimap-viewport-rect").boundingBox();
@@ -26,6 +33,54 @@ test("dragging the minimap viewport rectangle pans the main diagram viewport", a
 
   await expect.poll(async () => readDiagramScrollPosition(page)).not.toEqual(previousScroll);
 });
+
+async function expectMinimapEdgesToStayInsideSurface(page: Page): Promise<void> {
+  const surface = page.getByTestId("minimap-surface");
+  const edgeMarkers = page.getByTestId("minimap-edge-marker");
+
+  await expect
+    .poll(async () => {
+      const surfaceRect = await surface.boundingBox();
+      const markerRects = await edgeMarkers.evaluateAll((elements) =>
+        elements.map((element) => {
+          const rect = element.getBoundingClientRect();
+
+          return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top };
+        })
+      );
+
+      return hasStableMinimapEdgeBounds(surfaceRect, markerRects);
+    })
+    .toBe(true);
+}
+
+function hasStableMinimapEdgeBounds(
+  surfaceRect: { height: number; width: number; x: number; y: number } | null,
+  markerRects: Array<{ bottom: number; left: number; right: number; top: number }>
+): boolean {
+  return surfaceRect !== null && markerRects.length > 0 && markerRects.every((rect) => isMarkerInsideSurface(surfaceRect, rect));
+}
+
+function isMarkerInsideSurface(
+  surfaceRect: { height: number; width: number; x: number; y: number },
+  markerRect: { bottom: number; left: number; right: number; top: number }
+): boolean {
+  return isMarkerInsideSurfaceX(surfaceRect, markerRect) && isMarkerInsideSurfaceY(surfaceRect, markerRect);
+}
+
+function isMarkerInsideSurfaceX(
+  surfaceRect: { height: number; width: number; x: number; y: number },
+  markerRect: { bottom: number; left: number; right: number; top: number }
+): boolean {
+  return markerRect.left >= surfaceRect.x - 2 && markerRect.right <= surfaceRect.x + surfaceRect.width + 2;
+}
+
+function isMarkerInsideSurfaceY(
+  surfaceRect: { height: number; width: number; x: number; y: number },
+  markerRect: { bottom: number; left: number; right: number; top: number }
+): boolean {
+  return markerRect.top >= surfaceRect.y - 2 && markerRect.bottom <= surfaceRect.y + surfaceRect.height + 2;
+}
 
 function assertLayoutBox(input: {
   height: number;

--- a/packages/web-player/src/lib/diagram-minimap.ts
+++ b/packages/web-player/src/lib/diagram-minimap.ts
@@ -458,11 +458,11 @@ function toRelativePoint(
   element: SVGElement,
   point: { x: number; y: number }
 ): { x: number; y: number } {
-  const svgOrigin = readSvgOrigin(contentRect, element);
+  const svgProjection = readSvgProjection(contentRect, element);
 
   return {
-    x: svgOrigin.x + point.x,
-    y: svgOrigin.y + point.y
+    x: svgProjection.x + point.x * svgProjection.scaleX,
+    y: svgProjection.y + point.y * svgProjection.scaleY
   };
 }
 
@@ -472,25 +472,67 @@ function readLinePoint(input: {
   xAttribute: "x1" | "x2";
   yAttribute: "y1" | "y2";
 }): { x: number; y: number } {
-  const svgOrigin = readSvgOrigin(input.contentRect, input.element);
+  const svgProjection = readSvgProjection(input.contentRect, input.element);
 
   return {
-    x: svgOrigin.x + sanitizeFiniteValue(input.element[input.xAttribute].baseVal.value),
-    y: svgOrigin.y + sanitizeFiniteValue(input.element[input.yAttribute].baseVal.value)
+    x: svgProjection.x + readScaledCoordinate(input.element[input.xAttribute].baseVal.value, svgProjection.scaleX),
+    y: svgProjection.y + readScaledCoordinate(input.element[input.yAttribute].baseVal.value, svgProjection.scaleY)
   };
 }
 
-function readSvgOrigin(contentRect: DOMRect, element: SVGElement): { x: number; y: number } {
-  const svgRect = element.ownerSVGElement?.getBoundingClientRect();
+function readScaledCoordinate(value: number, scale: number): number {
+  return sanitizeFiniteValue(value) * scale;
+}
 
-  if (svgRect === undefined) {
-    return { x: 0, y: 0 };
+function readSvgProjection(
+  contentRect: DOMRect,
+  element: SVGElement
+): { scaleX: number; scaleY: number; x: number; y: number } {
+  const svg = readProjectionSvg(element);
+
+  if (svg === null) {
+    return createDefaultSvgProjection();
   }
 
+  const svgRect = svg.getBoundingClientRect();
+  const svgDataset = readSvgDataset(svg);
+
   return {
+    scaleX: readSvgAxisScale(svgDataset.intrinsicWidth, svgRect.width),
+    scaleY: readSvgAxisScale(svgDataset.intrinsicHeight, svgRect.height),
     x: svgRect.left - contentRect.left,
     y: svgRect.top - contentRect.top
   };
+}
+
+function createDefaultSvgProjection(): { scaleX: number; scaleY: number; x: number; y: number } {
+  return { scaleX: 1, scaleY: 1, x: 0, y: 0 };
+}
+
+function readProjectionSvg(element: SVGElement): SVGSVGElement | null {
+  const svg = element.ownerSVGElement ?? null;
+
+  return hasProjectionSvgRect(svg) ? svg : null;
+}
+
+function hasProjectionSvgRect(svg: SVGSVGElement | null): svg is SVGSVGElement {
+  return svg !== null && typeof svg.getBoundingClientRect === "function";
+}
+
+function readSvgDataset(svg: SVGSVGElement): DOMStringMap {
+  return "dataset" in svg ? svg.dataset : {};
+}
+
+function readSvgAxisScale(intrinsicSize: string | undefined, renderedSize: number): number {
+  const intrinsicValue = sanitizeFiniteValue(Number(intrinsicSize));
+
+  if (intrinsicValue <= 0) {
+    return 1;
+  }
+
+  const renderedValue = sanitizeFiniteValue(renderedSize);
+
+  return renderedValue <= 0 ? 1 : renderedValue / intrinsicValue;
 }
 
 function toConnectorSegmentsFromPoints(points: Array<{ x: number; y: number }>): DiagramMinimapConnectorSegment[] {

--- a/packages/web-player/src/lib/diagram-zoom.ts
+++ b/packages/web-player/src/lib/diagram-zoom.ts
@@ -4,6 +4,14 @@ export const DEFAULT_ZOOM_SCALE = 1;
 export const MIN_ZOOM_SCALE = 0.5;
 export const MAX_ZOOM_SCALE = 2;
 export const ZOOM_SCALE_STEP = 0.25;
+const FIT_VIEW_PADDING = 32;
+
+export interface DiagramZoomContentBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
 
 export function canZoomIn(scale: number): boolean {
   return scale < MAX_ZOOM_SCALE;
@@ -28,6 +36,50 @@ export function createNextZoomScale(
 
 export function formatZoomPercentage(scale: number): string {
   return `${Math.round(clampZoomScale(scale) * 100)}%`;
+}
+
+export function createContentZoomToFitScale(input: {
+  bounds: DiagramZoomContentBounds;
+  svgHeight: number;
+  svgWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}): number | null {
+  const normalizedBounds = readNormalizedFitBounds(input);
+
+  if (normalizedBounds === null) {
+    return null;
+  }
+
+  return clampZoomScale(
+    Math.min(
+      readAvailableViewport(input.viewportWidth) / normalizedBounds.width,
+      readAvailableViewport(input.viewportHeight) / normalizedBounds.height,
+    ),
+  );
+}
+
+export function createCenteredContentScrollPosition(input: {
+  bounds: DiagramZoomContentBounds;
+  metrics: DiagramMinimapMetrics;
+}): {
+  scrollLeft: number;
+  scrollTop: number;
+} | null {
+  if (!hasStableMetrics(input.metrics) || !hasStableZoomBounds(input.bounds)) {
+    return null;
+  }
+
+  return {
+    scrollLeft: clampScrollTarget(
+      input.bounds.left + input.bounds.width / 2 - input.metrics.viewportWidth / 2,
+      input.metrics.contentWidth - input.metrics.viewportWidth,
+    ),
+    scrollTop: clampScrollTarget(
+      input.bounds.top + input.bounds.height / 2 - input.metrics.viewportHeight / 2,
+      input.metrics.contentHeight - input.metrics.viewportHeight,
+    ),
+  };
 }
 
 export function createPreservedZoomScrollPosition(input: {
@@ -115,6 +167,35 @@ function roundToQuarterStep(scale: number): number {
   return Math.round(scale / ZOOM_SCALE_STEP) * ZOOM_SCALE_STEP;
 }
 
+function normalizeBoundsToSvg(
+  bounds: DiagramZoomContentBounds,
+  svgSize: { height: number; width: number },
+): DiagramZoomContentBounds | null {
+  const left = clampBoundsOrigin(bounds.left, svgSize.width);
+  const top = clampBoundsOrigin(bounds.top, svgSize.height);
+  const right = clampBoundsOrigin(bounds.left + bounds.width, svgSize.width);
+  const bottom = clampBoundsOrigin(bounds.top + bounds.height, svgSize.height);
+  const width = right - left;
+  const height = bottom - top;
+
+  return width > 0 && height > 0 ? { left, top, width, height } : null;
+}
+
+function readNormalizedFitBounds(input: {
+  bounds: DiagramZoomContentBounds;
+  svgHeight: number;
+  svgWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}): DiagramZoomContentBounds | null {
+  return hasStableZoomBounds(input.bounds) && hasStableViewportSize(input)
+    ? normalizeBoundsToSvg(input.bounds, {
+        height: input.svgHeight,
+        width: input.svgWidth,
+      })
+    : null;
+}
+
 function readIntrinsicSvgSize(
   svg: SVGSVGElement,
 ): { height: number; width: number } | null {
@@ -187,8 +268,37 @@ function readPositiveFiniteNumber(value: string | null): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
+function hasStableZoomBounds(bounds: DiagramZoomContentBounds): boolean {
+  return hasFiniteBoundsOrigin(bounds) && hasFiniteBoundsSize(bounds);
+}
+
 function hasStableMetrics(metrics: DiagramMinimapMetrics): boolean {
   return hasStableContent(metrics) && hasStableViewport(metrics);
+}
+
+function hasStableViewportSize(input: {
+  svgHeight: number;
+  svgWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}): boolean {
+  return (
+    hasStableSvgSize({ height: input.svgHeight, width: input.svgWidth }) &&
+    isFinitePositive(input.viewportWidth) &&
+    isFinitePositive(input.viewportHeight)
+  );
+}
+
+function hasStableSvgSize(size: { height: number; width: number }): boolean {
+  return isFinitePositive(size.width) && isFinitePositive(size.height);
+}
+
+function hasFiniteBoundsOrigin(bounds: DiagramZoomContentBounds): boolean {
+  return Number.isFinite(bounds.left) && Number.isFinite(bounds.top);
+}
+
+function hasFiniteBoundsSize(bounds: DiagramZoomContentBounds): boolean {
+  return isFinitePositive(bounds.width) && isFinitePositive(bounds.height);
 }
 
 function hasStableContent(metrics: DiagramMinimapMetrics): boolean {
@@ -226,6 +336,24 @@ function clampScrollTarget(target: number, maxScroll: number): number {
   }
 
   return Math.round(sanitizedTarget);
+}
+
+function clampBoundsOrigin(value: number, maxValue: number): number {
+  const sanitizedValue = sanitizeFiniteValue(value);
+
+  if (sanitizedValue < 0) {
+    return 0;
+  }
+
+  if (sanitizedValue > maxValue) {
+    return maxValue;
+  }
+
+  return sanitizedValue;
+}
+
+function readAvailableViewport(value: number): number {
+  return Math.max(1, sanitizeFiniteValue(value) - FIT_VIEW_PADDING * 2);
 }
 
 function isFinitePositive(value: number): boolean {

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -15,11 +15,13 @@
     applySvgZoom,
     canZoomIn,
     canZoomOut,
+    createCenteredContentScrollPosition,
+    createContentZoomToFitScale,
     createNextZoomScale,
     createPreservedZoomScrollPosition,
-    createZoomToFitScale,
     DEFAULT_ZOOM_SCALE,
-    formatZoomPercentage
+    formatZoomPercentage,
+    type DiagramZoomContentBounds
   } from "$lib/diagram-zoom";
   import {
     createDiagramMinimapGeometry,
@@ -32,7 +34,7 @@
     type DiagramMinimapRect,
     type DiagramMinimapMetrics
   } from "$lib/diagram-minimap";
-  import { createOverviewScrollPosition, focusDiagramViewport } from "$lib/diagram-viewport";
+  import { focusDiagramViewport } from "$lib/diagram-viewport";
   import { createFocusGroup, type FocusGroup } from "$lib/focus-group";
   import { createTourPlayer } from "$lib/player-state";
   import {
@@ -78,6 +80,11 @@
   const INTERACTIVE_DIAGRAM_ELEMENT_SELECTOR = [
     '[data-diagram-element-id]:not([data-diagram-element-auxiliary="true"])',
     '[data-node-id]:not([data-diagram-element-auxiliary="true"])'
+  ].join(", ");
+  const DIAGRAM_FIT_ELEMENT_SELECTOR = [
+    "[data-diagram-element-id]",
+    "[data-node-id]",
+    "[data-connector-role]"
   ].join(", ");
 
   type ViewportDragInput = {
@@ -142,7 +149,19 @@
   }
 
   async function resetZoom(): Promise<void> {
-    await updateZoomScale(DEFAULT_ZOOM_SCALE);
+    const zoomContext = readZoomContext();
+
+    if (zoomContext === null) {
+      return;
+    }
+
+    if (!applyZoomScaleToSvg(zoomContext.svg, DEFAULT_ZOOM_SCALE)) {
+      return;
+    }
+
+    zoomScale = DEFAULT_ZOOM_SCALE;
+    await waitForDiagramLayout();
+    centerZoomViewportOnDiagram(zoomContext.context);
   }
 
   async function fitZoomToView(): Promise<void> {
@@ -152,38 +171,12 @@
       return;
     }
 
-    if (!applyZoomToFitScale(zoomContext)) {
+    if (!applyContentFitZoomScale(zoomContext)) {
       return;
     }
 
     await waitForDiagramLayout();
-
-    const nextPosition = createOverviewScrollPosition(readCurrentMetrics(zoomContext.context));
-
-    writeDiagramScrollPosition(nextPosition, "auto");
-  }
-
-  function applyZoomToFitScale(zoomContext: {
-    context: { container: HTMLDivElement; content: HTMLDivElement };
-    svg: SVGSVGElement;
-  }): boolean {
-    const previousMetrics = readDiagramMinimapMetrics(zoomContext.context);
-    const nextZoomScale = createZoomToFitScale({
-      currentScale: zoomScale,
-      metrics: previousMetrics
-    });
-
-    if (nextZoomScale === null) {
-      return false;
-    }
-
-    if (!applyZoomScaleToSvg(zoomContext.svg, nextZoomScale)) {
-      return false;
-    }
-
-    zoomScale = nextZoomScale;
-
-    return true;
+    centerZoomViewportOnDiagram(zoomContext.context);
   }
 
   async function syncFocusState(behavior: ScrollBehavior = "smooth"): Promise<void> {
@@ -457,6 +450,59 @@
     return applySvgZoom(svg, nextZoomScale);
   }
 
+  function createContentFitZoomScale(zoomContext: {
+    context: { container: HTMLDivElement; content: HTMLDivElement };
+    svg: SVGSVGElement;
+  }): number | null {
+    const contentBounds = readIntrinsicDiagramBounds(zoomContext);
+    const svgSize = readZoomSvgSize(zoomContext.svg);
+
+    return contentBounds === null || svgSize === null
+      ? null
+      : createContentZoomToFitScale({
+          bounds: contentBounds,
+          svgHeight: svgSize.height,
+          svgWidth: svgSize.width,
+          viewportHeight: zoomContext.context.container.clientHeight,
+          viewportWidth: zoomContext.context.container.clientWidth
+        });
+  }
+
+  function applyContentFitZoomScale(zoomContext: {
+    context: { container: HTMLDivElement; content: HTMLDivElement };
+    svg: SVGSVGElement;
+  }): boolean {
+    return applyNextZoomScale(zoomContext.svg, createContentFitZoomScale(zoomContext));
+  }
+
+  function centerZoomViewportOnDiagram(
+    context: { container: HTMLDivElement; content: HTMLDivElement }
+  ): void {
+    const contentBounds = readRenderedDiagramBounds(context.content);
+
+    if (contentBounds === null) {
+      return;
+    }
+
+    writeDiagramScrollPosition(
+      createCenteredContentScrollPosition({
+        bounds: contentBounds,
+        metrics: readCurrentMetrics(context)
+      }),
+      "auto"
+    );
+  }
+
+  function applyNextZoomScale(svg: SVGSVGElement, nextZoomScale: number | null): boolean {
+    if (nextZoomScale === null || !applyZoomScaleToSvg(svg, nextZoomScale)) {
+      return false;
+    }
+
+    zoomScale = nextZoomScale;
+
+    return true;
+  }
+
   function preserveZoomViewport(context: {
     container: HTMLDivElement;
     content: HTMLDivElement;
@@ -474,6 +520,164 @@
     content: HTMLDivElement;
   }): DiagramMinimapMetrics {
     return readDiagramMinimapMetrics(context);
+  }
+
+  function readIntrinsicDiagramBounds(zoomContext: {
+    context: { container: HTMLDivElement; content: HTMLDivElement };
+    svg: SVGSVGElement;
+  }): DiagramZoomContentBounds | null {
+    const renderedBounds = readRenderedDiagramBounds(zoomContext.context.content);
+    const svgOrigin = readRenderedSvgOrigin(zoomContext.context.content, zoomContext.svg);
+    const currentZoomScale = readZoomScaleFromSvg(zoomContext.svg);
+
+    if (hasMissingIntrinsicBoundsInput(renderedBounds, svgOrigin, currentZoomScale)) {
+      return null;
+    }
+
+    const intrinsicBoundsInput = {
+      currentZoomScale,
+      renderedBounds,
+      svgOrigin
+    } as {
+      currentZoomScale: number;
+      renderedBounds: DiagramZoomContentBounds;
+      svgOrigin: { left: number; top: number };
+    };
+
+    return createIntrinsicDiagramBounds({
+      currentZoomScale: intrinsicBoundsInput.currentZoomScale,
+      renderedBounds: intrinsicBoundsInput.renderedBounds,
+      svgOrigin: intrinsicBoundsInput.svgOrigin
+    });
+  }
+
+  function readRenderedDiagramBounds(content: HTMLDivElement): DiagramZoomContentBounds | null {
+    return mergeDiagramBounds(
+      Array.from(content.querySelectorAll<Element>(DIAGRAM_FIT_ELEMENT_SELECTOR))
+        .map((element) => toRenderedDiagramBounds(content, element))
+        .filter((bounds): bounds is DiagramZoomContentBounds => bounds !== null)
+    );
+  }
+
+  function toRenderedDiagramBounds(
+    content: HTMLDivElement,
+    element: Element
+  ): DiagramZoomContentBounds | null {
+    const contentRect = content.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+
+    return hasUsableDiagramRect(elementRect)
+      ? {
+          left: elementRect.left - contentRect.left,
+          top: elementRect.top - contentRect.top,
+          width: elementRect.width,
+          height: elementRect.height
+        }
+      : null;
+  }
+
+  function mergeDiagramBounds(boundsList: DiagramZoomContentBounds[]): DiagramZoomContentBounds | null {
+    if (boundsList.length === 0) {
+      return null;
+    }
+
+    return boundsList.reduce((currentBounds, bounds) => {
+      const right = Math.max(currentBounds.left + currentBounds.width, bounds.left + bounds.width);
+      const bottom = Math.max(currentBounds.top + currentBounds.height, bounds.top + bounds.height);
+      const left = Math.min(currentBounds.left, bounds.left);
+      const top = Math.min(currentBounds.top, bounds.top);
+
+      return {
+        left,
+        top,
+        width: right - left,
+        height: bottom - top
+      };
+    });
+  }
+
+  function readRenderedSvgOrigin(
+    content: HTMLDivElement,
+    svg: SVGSVGElement
+  ): { left: number; top: number } | null {
+    const contentRect = content.getBoundingClientRect();
+    const svgRect = svg.getBoundingClientRect();
+
+    return hasUsableDiagramRect(svgRect)
+      ? {
+          left: svgRect.left - contentRect.left,
+          top: svgRect.top - contentRect.top
+        }
+      : null;
+  }
+
+  function readZoomScaleFromSvg(svg: SVGSVGElement): number | null {
+    return readPositiveFiniteNumber(svg.dataset.zoomScale ?? String(zoomScale));
+  }
+
+  function readZoomSvgSize(svg: SVGSVGElement): { height: number; width: number } | null {
+    const currentZoomScale = readZoomScaleFromSvg(svg);
+    const width = readZoomSvgDimension(svg.dataset.intrinsicWidth, svg.getAttribute("width"), currentZoomScale);
+    const height = readZoomSvgDimension(
+      svg.dataset.intrinsicHeight,
+      svg.getAttribute("height"),
+      currentZoomScale
+    );
+
+    return width === null || height === null ? null : { height, width };
+  }
+
+  function readZoomSvgDimension(
+    intrinsicValue: string | undefined,
+    renderedValue: string | null,
+    currentZoomScale: number | null
+  ): number | null {
+    return (
+      readPositiveFiniteNumber(intrinsicValue ?? null) ??
+      readRenderedZoomSvgDimension(renderedValue, currentZoomScale)
+    );
+  }
+
+  function hasUsableDiagramRect(rect: DOMRect): boolean {
+    return [rect.left, rect.top, rect.width, rect.height].every(Number.isFinite) && rect.width > 0 && rect.height > 0;
+  }
+
+  function hasMissingIntrinsicBoundsInput(
+    renderedBounds: DiagramZoomContentBounds | null,
+    svgOrigin: { left: number; top: number } | null,
+    currentZoomScale: number | null
+  ): boolean {
+    return renderedBounds === null || svgOrigin === null || currentZoomScale === null;
+  }
+
+  function createIntrinsicDiagramBounds(input: {
+    currentZoomScale: number;
+    renderedBounds: DiagramZoomContentBounds;
+    svgOrigin: { left: number; top: number };
+  }): DiagramZoomContentBounds {
+    return {
+      left: (input.renderedBounds.left - input.svgOrigin.left) / input.currentZoomScale,
+      top: (input.renderedBounds.top - input.svgOrigin.top) / input.currentZoomScale,
+      width: input.renderedBounds.width / input.currentZoomScale,
+      height: input.renderedBounds.height / input.currentZoomScale
+    };
+  }
+
+  function readRenderedZoomSvgDimension(
+    renderedValue: string | null,
+    currentZoomScale: number | null
+  ): number | null {
+    const renderedDimension = readPositiveFiniteNumber(renderedValue);
+
+    return renderedDimension === null || currentZoomScale === null
+      ? null
+      : renderedDimension / currentZoomScale;
+  }
+
+  function readPositiveFiniteNumber(value: string | null): number | null {
+    const parsed = Number(value);
+
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }
 
   async function handleDiagramClick(event: MouseEvent): Promise<void> {
@@ -1141,7 +1345,6 @@
           <button
             type="button"
             class="viewport-toolbar__button"
-            data-testid="zoom-out-button"
             aria-label="Zoom out"
             disabled={!canZoomOut(zoomScale)}
             on:click={() => void zoomOut()}
@@ -1158,23 +1361,22 @@
           </button>
           <button
             type="button"
-            class="viewport-toolbar__button viewport-toolbar__button--value"
-            data-testid="zoom-reset-button"
-            aria-label="Reset zoom to 100%"
-            disabled={zoomScale === DEFAULT_ZOOM_SCALE}
-            on:click={() => void resetZoom()}
-          >
-            {formatZoomPercentage(zoomScale)}
-          </button>
-          <button
-            type="button"
             class="viewport-toolbar__button"
-            data-testid="zoom-in-button"
             aria-label="Zoom in"
             disabled={!canZoomIn(zoomScale)}
             on:click={() => void zoomIn()}
           >
             +
+          </button>
+          <p class="viewport-toolbar__value">{formatZoomPercentage(zoomScale)}</p>
+          <button
+            type="button"
+            class="viewport-toolbar__button"
+            aria-label="Reset zoom to 100%"
+            disabled={zoomScale === DEFAULT_ZOOM_SCALE}
+            on:click={() => void resetZoom()}
+          >
+            100%
           </button>
         </div>
       <aside class="step-panel step-panel--overlay">
@@ -1318,11 +1520,11 @@
           </aside>
 
           <aside class="viewport-toolbar" data-testid="viewport-toolbar">
-            <p class="viewport-toolbar__value" data-testid="zoom-value">{formatZoomPercentage(zoomScale)}</p>
-            <div class="viewport-toolbar__actions">
+            <div class="viewport-toolbar__actions" data-testid="zoom-primary-controls">
               <button
                 type="button"
                 class="viewport-toolbar__button"
+                data-testid="zoom-out-button"
                 aria-label="Zoom out"
                 disabled={!canZoomOut(zoomScale)}
                 on:click={() => void zoomOut()}
@@ -1341,6 +1543,7 @@
               <button
                 type="button"
                 class="viewport-toolbar__button"
+                data-testid="zoom-in-button"
                 aria-label="Zoom in"
                 disabled={!canZoomIn(zoomScale)}
                 on:click={() => void zoomIn()}
@@ -1348,6 +1551,17 @@
                 +
               </button>
             </div>
+            <p class="viewport-toolbar__value" data-testid="zoom-value">{formatZoomPercentage(zoomScale)}</p>
+            <button
+              type="button"
+              class="viewport-toolbar__button"
+              data-testid="zoom-one-hundred-button"
+              aria-label="Reset zoom to 100%"
+              disabled={zoomScale === DEFAULT_ZOOM_SCALE}
+              on:click={() => void resetZoom()}
+            >
+              100%
+            </button>
           </aside>
         </div>
       </div>

--- a/packages/web-player/src/routes/+layout.svelte
+++ b/packages/web-player/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { afterNavigate, goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { toast } from "svelte-sonner";
@@ -69,9 +69,14 @@
   let diagnosticIssueCount = countDiagnosticIssues(diagnosticGroups);
   let isHydrated = false;
   let breadcrumbs = ["diagram-tours", "collection"];
+  let currentPathname: string = page.url.pathname;
+
+  afterNavigate((navigation) => {
+    currentPathname = navigation.to?.url.pathname ?? window.location.pathname;
+  });
 
   $: {
-    activeSlug = readActiveSlug(page.url.pathname);
+    activeSlug = readActiveSlug(currentPathname);
     activeEntry = readActiveEntry(data.collection.entries, activeSlug);
     diagnosticGroups = createDiagnosticDisplayGroups(data.collection.skipped);
     diagnosticIssueCount = countDiagnosticIssues(diagnosticGroups);
@@ -106,7 +111,7 @@
 
     closeDiagnostics();
     browseOpenedAt = Date.now();
-    browseOpenedForPath = page.url.pathname;
+    browseOpenedForPath = currentPathname;
     isBrowseOpen = true;
     activeBrowseSlug = readInitialBrowsePaletteSlug({
       activeSlug: null,
@@ -189,7 +194,7 @@
     recentSlugs = readStoredRecentSlugs(window.localStorage);
     browseShortcutHint = isMacPlatform(window.navigator) ? "Cmd K" : "Ctrl K";
     setDocumentTheme(document, theme);
-    previousPathname = page.url.pathname;
+    previousPathname = currentPathname;
     isHydrated = true;
     rememberActiveSlug(activeSlug);
     window.addEventListener("diagram-tour-toggle-browse", handleExternalBrowseToggle);
@@ -199,9 +204,9 @@
     };
   });
 
-  $: if (page.url.pathname !== previousPathname) {
-    previousPathname = page.url.pathname;
-    if (browseOpenedForPath !== page.url.pathname) {
+  $: if (currentPathname !== previousPathname) {
+    previousPathname = currentPathname;
+    if (browseOpenedForPath !== currentPathname) {
       closeBrowse();
     }
     closeDiagnostics();
@@ -222,7 +227,10 @@
   }
 
   async function navigateToBrowseSlug(slug: string): Promise<void> {
+    const nextPathname = resolve(`/${slug}`);
+
     closeBrowse();
+    currentPathname = nextPathname;
     await goto(resolve(`/${slug}`));
   }
 

--- a/packages/web-player/src/routes/[...tourSlug]/+page.ts
+++ b/packages/web-player/src/routes/[...tourSlug]/+page.ts
@@ -1,7 +1,7 @@
 import { error } from "@sveltejs/kit";
-import type { PageServerLoad } from "./$types";
+import type { PageLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ params, parent, url }) => {
+export const load: PageLoad = async ({ params, parent, url }) => {
   const { collection } = await parent();
   const selectedSlug = params.tourSlug;
   const entry = collection.entries.find(

--- a/packages/web-player/src/styles/components/cards.css
+++ b/packages/web-player/src/styles/components/cards.css
@@ -58,7 +58,7 @@
   border-radius: 0;
   display: flex;
   gap: 0.55rem;
-  justify-content: space-between;
+  justify-content: flex-start;
   max-width: 100%;
   padding: 0.65rem 0.1rem 0.1rem;
   width: 100%;
@@ -71,6 +71,10 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   margin: 0;
+}
+
+.viewport-toolbar > .viewport-toolbar__value {
+  margin-inline-start: auto;
 }
 
 .viewport-toolbar__actions {

--- a/packages/web-player/src/styles/components/diagram-player.css
+++ b/packages/web-player/src/styles/components/diagram-player.css
@@ -330,9 +330,10 @@
 
 .teleprompter__navleft,
 .teleprompter__navright {
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 0.45rem;
 }
 
 .teleprompter__textarea {

--- a/packages/web-player/test/diagram-minimap.test.ts
+++ b/packages/web-player/test/diagram-minimap.test.ts
@@ -268,6 +268,62 @@ describe("diagram minimap helpers", () => {
     ]);
   });
 
+  it("scales sampled connector geometry with the rendered svg zoom", () => {
+    const fixture = createFixture();
+    const svg = readSvg(fixture.content) as SVGSVGElement & {
+      dataset: Record<string, string>;
+    };
+
+    svg.dataset = {
+      intrinsicHeight: "600",
+      intrinsicWidth: "740"
+    };
+    mockRect(svg, { height: 1200, left: 40, top: 30, width: 1480 });
+    mockConnector(fixture, ".flowchart-link", createPathConnectorStub([
+      { x: 120, y: 80 },
+      { x: 220, y: 80 }
+    ]));
+
+    expect(
+      readDiagramMinimapConnectors({
+        content: fixture.content
+      })
+    ).toEqual([
+      {
+        arrowhead: { angle: 0, x: 480, y: 190 },
+        segments: expect.arrayContaining([{ x1: 280, y1: 190, x2: 320, y2: 190 }])
+      }
+    ]);
+  });
+
+  it("falls back to unscaled connector geometry when rendered svg bounds collapse", () => {
+    const fixture = createFixture();
+    const svg = readSvg(fixture.content) as SVGSVGElement & {
+      dataset: Record<string, string>;
+    };
+
+    svg.dataset = {
+      intrinsicHeight: "600",
+      intrinsicWidth: "740"
+    };
+    mockRect(svg, { height: 0, left: 40, top: 30, width: 0 });
+    mockConnector(fixture, ".flowchart-link", createPathConnectorStub([
+      { x: 120, y: 80 },
+      { x: 220, y: 80 }
+    ]));
+
+    expect(
+      readDiagramMinimapConnectors({
+        content: fixture.content
+      })
+    ).toEqual([
+      {
+        arrowhead: { angle: 0, x: 260, y: 110 },
+        segments: expect.arrayContaining([{ x1: 160, y1: 110, x2: 180, y2: 110 }])
+      }
+    ]);
+  });
+
   it("defaults connector geometry to an empty list when connectors are omitted", () => {
     expect(
       createDiagramMinimapGeometry({

--- a/packages/web-player/test/diagram-zoom.test.ts
+++ b/packages/web-player/test/diagram-zoom.test.ts
@@ -4,6 +4,8 @@ import {
   applySvgZoom,
   canZoomIn,
   canZoomOut,
+  createCenteredContentScrollPosition,
+  createContentZoomToFitScale,
   createNextZoomScale,
   createPreservedZoomScrollPosition,
   createZoomToFitScale,
@@ -105,8 +107,6 @@ describe("diagram zoom helpers", () => {
     ).toBeNull();
   });
 
-  it("returns null when zoom preservation metrics are unstable", () => {});
-
   it("returns null when zoom preservation metrics are unstable", () => {
     expect(
       createPreservedZoomScrollPosition({
@@ -114,6 +114,127 @@ describe("diagram zoom helpers", () => {
         previousMetrics: createMetrics({
           contentWidth: 0,
         }),
+      }),
+    ).toBeNull();
+  });
+
+  it("creates a fit scale from real content bounds instead of the stage size", () => {
+    expect(
+      createContentZoomToFitScale({
+        bounds: {
+          height: 120,
+          left: 180,
+          top: 140,
+          width: 320,
+        },
+        svgHeight: 640,
+        svgWidth: 960,
+        viewportHeight: 480,
+        viewportWidth: 720,
+      }),
+    ).toBe(2);
+  });
+
+  it("creates a fit scale that can zoom out for large diagrams", () => {
+    expect(
+      createContentZoomToFitScale({
+        bounds: {
+          height: 560,
+          left: 0,
+          top: 0,
+          width: 1400,
+        },
+        svgHeight: 640,
+        svgWidth: 1600,
+        viewportHeight: 480,
+        viewportWidth: 720,
+      }),
+    ).toBe(0.5);
+  });
+
+  it("returns null when real-content fit inputs are unstable", () => {
+    expect(
+      createContentZoomToFitScale({
+        bounds: {
+          height: 0,
+          left: 0,
+          top: 0,
+          width: 400,
+        },
+        svgHeight: 640,
+        svgWidth: 960,
+        viewportHeight: 480,
+        viewportWidth: 720,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when clamped real-content bounds collapse outside the svg", () => {
+    expect(
+      createContentZoomToFitScale({
+        bounds: {
+          height: 80,
+          left: 980,
+          top: 120,
+          width: 120,
+        },
+        svgHeight: 640,
+        svgWidth: 960,
+        viewportHeight: 480,
+        viewportWidth: 720,
+      }),
+    ).toBeNull();
+  });
+
+  it("clamps negative real-content bounds back into the svg before fitting", () => {
+    expect(
+      createContentZoomToFitScale({
+        bounds: {
+          height: 100,
+          left: -20,
+          top: -10,
+          width: 200,
+        },
+        svgHeight: 640,
+        svgWidth: 960,
+        viewportHeight: 480,
+        viewportWidth: 720,
+      }),
+    ).toBe(2);
+  });
+
+  it("recenters the viewport on real content bounds", () => {
+    expect(
+      createCenteredContentScrollPosition({
+        bounds: {
+          height: 84,
+          left: 150,
+          top: 290,
+          width: 1098,
+        },
+        metrics: createMetrics({
+          contentHeight: 920,
+          contentWidth: 1320,
+          viewportHeight: 480,
+          viewportWidth: 720,
+        }),
+      }),
+    ).toEqual({
+      scrollLeft: 339,
+      scrollTop: 92,
+    });
+  });
+
+  it("returns null when centered-content scroll inputs are unstable", () => {
+    expect(
+      createCenteredContentScrollPosition({
+        bounds: {
+          height: 84,
+          left: 150,
+          top: 290,
+          width: 0,
+        },
+        metrics: createMetrics(),
       }),
     ).toBeNull();
   });

--- a/packages/web-player/test/layout.svelte.test.ts
+++ b/packages/web-player/test/layout.svelte.test.ts
@@ -1,14 +1,30 @@
-import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { gotoMock, pageState } = vi.hoisted(() => ({
-  gotoMock: vi.fn(() => Promise.resolve()),
-  pageState: {
+const { afterNavigateMock, gotoMock, pageState, resetNavigationMocks, setPageUrl } = vi.hoisted(() => {
+  const currentPage = {
     url: new URL("https://example.test/payment-flow")
-  }
-}));
+  };
+  const afterNavigateCallbacks = new Set<(value: { to: { url: URL } }) => void>();
+
+  return {
+    afterNavigateMock(callback: (value: { to: { url: URL } }) => void) {
+      afterNavigateCallbacks.add(callback);
+    },
+    gotoMock: vi.fn(() => Promise.resolve()),
+    pageState: currentPage,
+    resetNavigationMocks() {
+      afterNavigateCallbacks.clear();
+    },
+    setPageUrl(url: string) {
+      currentPage.url = new URL(url);
+      afterNavigateCallbacks.forEach((run) => run({ to: currentPage }));
+    }
+  };
+});
 
 vi.mock("$app/navigation", () => ({
+  afterNavigate: afterNavigateMock,
   goto: gotoMock
 }));
 
@@ -36,9 +52,10 @@ const directorySourceTarget = {
 describe("+layout.svelte", () => {
   beforeEach(() => {
     gotoMock.mockClear();
+    resetNavigationMocks();
     window.localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
-    pageState.url = new URL("https://example.test/payment-flow");
+    setPageUrl("https://example.test/payment-flow");
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn(() => Promise.resolve())
@@ -187,7 +204,7 @@ describe("+layout.svelte", () => {
   });
 
   it("tracks the active row from the current route, arrow keys, and enter", async () => {
-    pageState.url = new URL("https://example.test/refund-flow");
+    setPageUrl("https://example.test/refund-flow");
 
     render(Layout, {
       data: {
@@ -231,7 +248,7 @@ describe("+layout.svelte", () => {
   });
 
   it("keeps the command palette open when reopened after a route change settles", async () => {
-    pageState.url = new URL("https://example.test/payment-flow");
+    setPageUrl("https://example.test/payment-flow");
 
     render(Layout, {
       data: {
@@ -240,7 +257,7 @@ describe("+layout.svelte", () => {
       }
     });
 
-    pageState.url = new URL("https://example.test/refund-flow");
+    setPageUrl("https://example.test/refund-flow");
     await fireEvent.click(screen.getByTestId("search-hint-trigger"));
 
     expect(await screen.findByTestId("browse-panel")).toBeDefined();
@@ -248,6 +265,23 @@ describe("+layout.svelte", () => {
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(screen.getByTestId("browse-panel")).toBeDefined();
+  });
+
+  it("updates breadcrumbs when the active route changes inside the shell", async () => {
+    render(Layout, {
+      data: {
+        collection: resolvedTourCollection,
+        sourceTarget: directorySourceTarget
+      }
+    });
+
+    expect(screen.getByTestId("topbar-breadcrumbs").textContent).toContain("Payment Flow");
+
+    setPageUrl("https://example.test/refund-flow");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("topbar-breadcrumbs").textContent).toContain("Refund Flow");
+    });
   });
 
   it("shows the preview notice for single-file author previews", async () => {

--- a/packages/web-player/test/tour-player.svelte.test.ts
+++ b/packages/web-player/test/tour-player.svelte.test.ts
@@ -185,6 +185,7 @@ describe("tour-player.svelte", () => {
     expect(screen.getByTestId("camera-control-panel").lastElementChild).toBe(
       screen.getByTestId("viewport-toolbar"),
     );
+    expect(screen.getByTestId("zoom-one-hundred-button")).toBeDefined();
     expect(
       container.querySelector('[data-testid="step-overlay"]'),
     ).not.toBeNull();
@@ -259,7 +260,7 @@ describe("tour-player.svelte", () => {
     );
   });
 
-  it("zooms the rendered svg and updates the segmented zoom value", async () => {
+  it("zooms the rendered svg, keeps the visible percentage separate, and enables the explicit 100 percent reset", async () => {
     render(TourPlayer, {
       initialStepIndex: 0,
       selectedSlug: "payment-flow",
@@ -274,6 +275,18 @@ describe("tour-player.svelte", () => {
     expect(screen.getByTestId("zoom-value").textContent).toContain(
       "100%",
     );
+    expect(
+      Array.from(screen.getByTestId("viewport-toolbar").children).map(
+        (element) => element.getAttribute("data-testid") ?? element.textContent?.trim(),
+      ),
+    ).toEqual(["zoom-primary-controls", "zoom-value", "zoom-one-hundred-button"]);
+    expect(screen.getByTestId("zoom-primary-controls").textContent?.replace(/\s+/gu, "")).toBe(
+      "-Fit+",
+    );
+    expect(
+      (screen.getByTestId("zoom-one-hundred-button") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
 
     await fireEvent.click(screen.getByTestId("zoom-in-button"));
 
@@ -283,6 +296,13 @@ describe("tour-player.svelte", () => {
       expect(screen.getByTestId("zoom-value").textContent).toContain(
         "125%",
       );
+      expect(screen.getByTestId("zoom-one-hundred-button").textContent).toBe(
+        "100%",
+      );
+      expect(
+        (screen.getByTestId("zoom-one-hundred-button") as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
     });
 
     await fireEvent.click(screen.getByTestId("zoom-out-button"));
@@ -296,7 +316,7 @@ describe("tour-player.svelte", () => {
     });
   });
 
-  it("fits the current diagram to the viewport when requested", async () => {
+  it("keeps fit stable after a manual zoom change", async () => {
     render(TourPlayer, {
       initialStepIndex: 0,
       selectedSlug: "payment-flow",
@@ -311,11 +331,52 @@ describe("tour-player.svelte", () => {
     await fireEvent.click(screen.getByTestId("zoom-fit-button"));
 
     await waitFor(() => {
-      expect(svg?.getAttribute("width")).toBe("480");
-      expect(svg?.getAttribute("height")).toBe("320");
+      expect(svg?.getAttribute("width")).toBe("720");
+      expect(svg?.getAttribute("height")).toBe("480");
       expect(screen.getByTestId("zoom-value").textContent).toContain(
-        "50%",
+        "75%",
       );
+    });
+
+    const fittedScrollLeft = diagramContainer.scrollLeft;
+    const fittedScrollTop = diagramContainer.scrollTop;
+
+    await fireEvent.click(screen.getByTestId("zoom-in-button"));
+
+    await waitFor(() => {
+      expect(svg?.getAttribute("width")).toBe("960");
+      expect(screen.getByTestId("zoom-value").textContent).toContain("100%");
+    });
+
+    await fireEvent.click(screen.getByTestId("zoom-fit-button"));
+
+    await waitFor(() => {
+      expect(svg?.getAttribute("width")).toBe("720");
+      expect(svg?.getAttribute("height")).toBe("480");
+      expect(diagramContainer.scrollLeft).toBe(fittedScrollLeft);
+      expect(diagramContainer.scrollTop).toBe(fittedScrollTop);
+    });
+  });
+
+  it("resets back to 100 percent and recenters on the diagram content", async () => {
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour,
+    });
+
+    const diagramContainer = await screen.findByTestId("diagram-container");
+    const svg = diagramContainer.querySelector("svg");
+
+    await fireEvent.click(screen.getByTestId("zoom-fit-button"));
+    await fireEvent.click(screen.getByTestId("zoom-one-hundred-button"));
+
+    await waitFor(() => {
+      expect(svg?.getAttribute("width")).toBe("960");
+      expect(svg?.getAttribute("height")).toBe("640");
+      expect(screen.getByTestId("zoom-value").textContent).toContain("100%");
+      expect(diagramContainer.scrollLeft).toBe(300);
+      expect(diagramContainer.scrollTop).toBe(234);
     });
   });
 
@@ -582,6 +643,7 @@ function renderDiagramForTest(input: {
 }): Promise<void> {
   const parent = input.container.parentElement as HTMLElement;
   const positions = createNodePositions();
+  const svgOrigin = { left: 180, top: 140 };
 
   input.container.innerHTML = `<svg data-testid="diagram-svg" width="960" height="640" data-intrinsic-width="960" data-intrinsic-height="640">${input.diagram.elements
     .map(
@@ -618,7 +680,12 @@ function renderDiagramForTest(input: {
   const svg = input.container.querySelector("svg") as SVGSVGElement;
 
   svg.getBoundingClientRect = () =>
-    createDomRect({ height: 640, left: 160, top: 140, width: 960 });
+    createDomRect({
+      height: readRenderedSvgDimension(svg, "height"),
+      left: svgOrigin.left,
+      top: svgOrigin.top,
+      width: readRenderedSvgDimension(svg, "width"),
+    });
 
   input.container
     .querySelectorAll<SVGGElement>("[data-node-id]")
@@ -626,7 +693,13 @@ function renderDiagramForTest(input: {
       const nodeId = element.dataset.nodeId ?? "";
       const rect = positions[nodeId];
 
-      element.getBoundingClientRect = () => createDomRect(rect);
+      element.getBoundingClientRect = () =>
+        createScaledNodeRect(rect, readRenderedZoomScale(svg), svgOrigin);
+      Object.assign(element, {
+        getBBox() {
+          return createSvgRect(rect);
+        },
+      });
     });
 
   const connector = input.container.querySelector(".flowchart-link") as SVGElement;
@@ -650,12 +723,12 @@ function renderDiagramForTest(input: {
 
 function createNodePositions(): Record<string, RectInput> {
   return {
-    api_gateway: { height: 82, left: 360, top: 290, width: 122 },
-    client: { height: 76, left: 150, top: 292, width: 118 },
-    payment_provider: { height: 84, left: 930, top: 290, width: 136 },
-    payment_service: { height: 84, left: 760, top: 290, width: 126 },
-    response: { height: 76, left: 1120, top: 292, width: 128 },
-    validation_service: { height: 84, left: 560, top: 290, width: 142 },
+    api_gateway: { height: 82, left: 220, top: 292, width: 122 },
+    client: { height: 76, left: 40, top: 294, width: 118 },
+    payment_provider: { height: 84, left: 690, top: 292, width: 136 },
+    payment_service: { height: 84, left: 540, top: 292, width: 126 },
+    response: { height: 76, left: 812, top: 294, width: 108 },
+    validation_service: { height: 84, left: 370, top: 292, width: 142 },
   };
 }
 
@@ -788,6 +861,19 @@ interface RectInput {
   width: number;
 }
 
+function createScaledNodeRect(
+  input: RectInput,
+  zoomScale: number,
+  svgOrigin: { left: number; top: number },
+): DOMRect {
+  return createDomRect({
+    height: input.height * zoomScale,
+    left: svgOrigin.left + input.left * zoomScale,
+    top: svgOrigin.top + input.top * zoomScale,
+    width: input.width * zoomScale,
+  });
+}
+
 function createDomRect(input: RectInput): DOMRect {
   return {
     bottom: input.top + input.height,
@@ -799,8 +885,28 @@ function createDomRect(input: RectInput): DOMRect {
   } as DOMRect;
 }
 
+function createSvgRect(input: RectInput): SVGRect {
+  return {
+    height: input.height,
+    width: input.width,
+    x: input.left,
+    y: input.top,
+  } as SVGRect;
+}
+
 function mockElementRect(element: Element, input: RectInput): void {
   element.getBoundingClientRect = () => createDomRect(input);
+}
+
+function readRenderedZoomScale(svg: SVGSVGElement): number {
+  return Number(svg.dataset.zoomScale ?? 1);
+}
+
+function readRenderedSvgDimension(
+  svg: SVGSVGElement,
+  axis: "height" | "width",
+): number {
+  return Number(svg.getAttribute(axis));
 }
 
 function createScrollToForTest(parent: HTMLElement): typeof parent.scrollTo {

--- a/packages/web-player/test/tour.page.server.test.ts
+++ b/packages/web-player/test/tour.page.server.test.ts
@@ -1,10 +1,10 @@
 import type { ResolvedDiagramTour } from "@diagram-tour/core";
 import { describe, expect, it } from "vitest";
 
-import { load } from "../src/routes/[...tourSlug]/+page.server";
+import { load } from "../src/routes/[...tourSlug]/+page";
 import { resolvedTourCollection } from "./fixtures/tour-collection";
 
-describe("tour +page.server", () => {
+describe("tour +page", () => {
   it("loads the selected tour from the collection", async () => {
     const result = (await load({
       params: {


### PR DESCRIPTION
## Summary
- make zoom-to-fit and 100% reset use real diagram bounds and update the zoom toolbar UX
- fix docs-shell breadcrumbs when switching diagrams and move tour route lookup client-side to avoid slow diagram-to-diagram navigation
- fix minimap connector drift under zoom and add targeted unit/smoke coverage for zoom, minimap, and browse navigation

## Validation
- `bun x eslint src/lib/diagram-minimap.ts src/lib/diagram-zoom.ts src/lib/tour-player.svelte src/routes/+layout.svelte src/routes/[...tourSlug]/+page.ts test/diagram-minimap.test.ts test/diagram-zoom.test.ts test/layout.svelte.test.ts test/tour-player.svelte.test.ts test/tour.page.server.test.ts smoke/checkout-decision.docs-shell-browse-navigation.spec.ts smoke/checkout-payment.zoom-controls.spec.ts smoke/ops-huge-system.minimap-drag-pans-viewport.spec.ts --max-warnings 0`
- `bun x stylelint src/styles/components/cards.css src/styles/components/diagram-player.css --max-warnings 0`
- `bun x vitest run --config ./vitest.config.ts test/diagram-minimap.test.ts --coverage.enabled --coverage.all true --coverage.include=src/lib/diagram-minimap.ts --coverage.reporter=text-summary --coverage.reportsDirectory=.coverage-diagram-minimap`
- `bun x vitest run --config ./vitest.config.ts test/diagram-zoom.test.ts --coverage.enabled --coverage.all true --coverage.include=src/lib/diagram-zoom.ts --coverage.reporter=text-summary --coverage.reportsDirectory=.coverage-diagram-zoom`
- `bun x vitest run --config ./vitest.config.ts test/layout.svelte.test.ts --coverage.enabled false`
- `bun x vitest run --config ./vitest.config.ts test/tour-player.svelte.test.ts --coverage.enabled false`
- `bun x vitest run --config ./vitest.config.ts test/tour.page.server.test.ts --coverage.enabled false`
- `bun run typecheck`
- `bun run build`
- `bun run smoke -- smoke/checkout-decision.docs-shell-browse-navigation.spec.ts`
- `bun run smoke -- smoke/checkout-payment.zoom-controls.spec.ts`
- `bun run smoke -- smoke/ops-huge-system.minimap-drag-pans-viewport.spec.ts`

## Notes
- local `bun.lock` line-ending noise remains uncommitted and is not part of this PR.