### PR TITLE
Fix smoke startup port handling for worktrees

### DIFF
--- a/packages/web-player/playwright.config.ts
+++ b/packages/web-player/playwright.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "@playwright/test";
+import { fileURLToPath } from "node:url";
 import { resolveSmokeServerPort } from "./smoke/smoke-port.js";
 
-const smokeServerPort = await resolveSmokeServerPort();
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const smokeServerPort = process.env.DIAGRAM_TOUR_SMOKE_PORT
+  ? Number(process.env.DIAGRAM_TOUR_SMOKE_PORT)
+  : await resolveSmokeServerPort({ worktreePath: repoRoot });
+
+process.env.DIAGRAM_TOUR_SMOKE_PORT ??= String(smokeServerPort);
+
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+const examplesTarget = fileURLToPath(new URL("../../examples", import.meta.url));
 
 export default defineConfig({
   testDir: "./smoke",
@@ -13,8 +22,14 @@ export default defineConfig({
     headless: true
   },
   webServer: {
-    command: `node ../../packages/cli/dist/bin/diagram-tours.js ../../examples --host 127.0.0.1 --port ${smokeServerPort} --no-open`,
-    port: smokeServerPort,
+    command: "node ./build/index.js",
+    cwd: packageRoot,
+    env: {
+      DIAGRAM_TOUR_SOURCE_TARGET: examplesTarget,
+      HOST: "127.0.0.1",
+      PORT: String(smokeServerPort)
+    },
+    url: `http://127.0.0.1:${smokeServerPort}`,
     reuseExistingServer: false,
     timeout: 120000
   }

--- a/packages/web-player/playwright.config.ts
+++ b/packages/web-player/playwright.config.ts
@@ -1,17 +1,20 @@
 import { defineConfig } from "@playwright/test";
+import { resolveSmokeServerPort } from "./smoke/smoke-port.js";
+
+const smokeServerPort = await resolveSmokeServerPort();
 
 export default defineConfig({
   testDir: "./smoke",
   fullyParallel: true,
   workers: 4,
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: `http://127.0.0.1:${smokeServerPort}`,
     browserName: "chromium",
     headless: true
   },
   webServer: {
-    command: "node ../../packages/cli/dist/bin/diagram-tours.js ../../examples --host 127.0.0.1 --port 4173 --no-open",
-    port: 4173,
+    command: `node ../../packages/cli/dist/bin/diagram-tours.js ../../examples --host 127.0.0.1 --port ${smokeServerPort} --no-open`,
+    port: smokeServerPort,
     reuseExistingServer: false,
     timeout: 120000
   }

--- a/packages/web-player/smoke/smoke-port.ts
+++ b/packages/web-player/smoke/smoke-port.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import { createServer, type AddressInfo } from "node:net";
+
+const SMOKE_PORT_BASE = 4173;
+const SMOKE_PORT_RANGE = 1000;
+const SMOKE_HOST = "127.0.0.1";
+
+export interface SmokePortSeed {
+  worktreePath?: string;
+  runId?: number;
+  probeLimit?: number;
+}
+
+export function readPreferredSmokePort(options: SmokePortSeed = {}): number {
+  const seed = createHash("sha256")
+    .update(`${readWorktreePath(options)}:${readRunId(options)}`)
+    .digest()
+    .readUInt32BE(0);
+
+  return SMOKE_PORT_BASE + (seed % SMOKE_PORT_RANGE);
+}
+
+export async function resolveSmokeServerPort(options: SmokePortSeed = {}): Promise<number> {
+  return await findAvailableSmokePort(readPreferredSmokePort(options), readProbeLimit(options));
+}
+
+function readWorktreePath(options: SmokePortSeed): string {
+  return options.worktreePath ?? process.cwd();
+}
+
+function readRunId(options: SmokePortSeed): number {
+  return options.runId ?? process.pid;
+}
+
+function readProbeLimit(options: SmokePortSeed): number {
+  return options.probeLimit ?? 32;
+}
+
+async function findAvailableSmokePort(preferredPort: number, probeLimit: number): Promise<number> {
+  for (let attempt = 0; attempt < probeLimit; attempt += 1) {
+    const port = SMOKE_PORT_BASE + ((preferredPort - SMOKE_PORT_BASE + attempt) % SMOKE_PORT_RANGE);
+
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+
+  return await readEphemeralPort();
+}
+
+async function readEphemeralPort(): Promise<number> {
+  const server = createServer();
+
+  return await new Promise<number>((resolvePort, rejectPort) => {
+    server.once("error", rejectPort);
+    server.listen(0, SMOKE_HOST, () => {
+      const port = (server.address() as AddressInfo).port;
+
+      server.close(() => {
+        resolvePort(port);
+      });
+    });
+  });
+}
+
+async function isPortAvailable(port: number): Promise<boolean> {
+  const server = createServer();
+
+  return await new Promise<boolean>((resolveAvailability) => {
+    server.once("error", () => {
+      resolveAvailability(false);
+    });
+    server.listen(port, SMOKE_HOST, () => {
+      server.close(() => {
+        resolveAvailability(true);
+      });
+    });
+  });
+}

--- a/packages/web-player/smoke/smoke-port.ts
+++ b/packages/web-player/smoke/smoke-port.ts
@@ -7,15 +7,11 @@ const SMOKE_HOST = "127.0.0.1";
 
 export interface SmokePortSeed {
   worktreePath?: string;
-  runId?: number;
   probeLimit?: number;
 }
 
 export function readPreferredSmokePort(options: SmokePortSeed = {}): number {
-  const seed = createHash("sha256")
-    .update(`${readWorktreePath(options)}:${readRunId(options)}`)
-    .digest()
-    .readUInt32BE(0);
+  const seed = createHash("sha256").update(readWorktreePath(options)).digest().readUInt32BE(0);
 
   return SMOKE_PORT_BASE + (seed % SMOKE_PORT_RANGE);
 }
@@ -26,10 +22,6 @@ export async function resolveSmokeServerPort(options: SmokePortSeed = {}): Promi
 
 function readWorktreePath(options: SmokePortSeed): string {
   return options.worktreePath ?? process.cwd();
-}
-
-function readRunId(options: SmokePortSeed): number {
-  return options.runId ?? process.pid;
 }
 
 function readProbeLimit(options: SmokePortSeed): number {

--- a/packages/web-player/test/smoke-port.test.ts
+++ b/packages/web-player/test/smoke-port.test.ts
@@ -21,29 +21,29 @@ afterEach(async () => {
 });
 
 describe("readPreferredSmokePort", () => {
-  it("returns a stable port for the same worktree and run id", () => {
-    const options = { worktreePath: "C:/worktrees/one", runId: 1234 };
+  it("returns a stable port for the same worktree", () => {
+    const options = { worktreePath: "C:/worktrees/one" };
 
     expect(readPreferredSmokePort(options)).toBe(readPreferredSmokePort(options));
   });
 
-  it("varies across different runs", () => {
+  it("varies across different worktrees", () => {
     const worktreePath = "C:/worktrees/one";
 
-    expect(readPreferredSmokePort({ worktreePath, runId: 1234 })).not.toBe(
-      readPreferredSmokePort({ worktreePath, runId: 1235 })
+    expect(readPreferredSmokePort({ worktreePath })).not.toBe(
+      readPreferredSmokePort({ worktreePath: "C:/worktrees/two" })
     );
   });
 });
 
 describe("resolveSmokeServerPort", () => {
   it("falls back to another free port when the preferred one is busy", async () => {
-    const preferredPort = readPreferredSmokePort({ worktreePath: "C:/worktrees/two", runId: 7 });
+    const preferredPort = readPreferredSmokePort({ worktreePath: "C:/worktrees/two" });
 
     await occupyPort(preferredPort);
 
     await expect(
-      resolveSmokeServerPort({ worktreePath: "C:/worktrees/two", runId: 7, probeLimit: 1 })
+      resolveSmokeServerPort({ worktreePath: "C:/worktrees/two", probeLimit: 1 })
     ).resolves.not.toBe(preferredPort);
   });
 });

--- a/packages/web-player/test/smoke-port.test.ts
+++ b/packages/web-player/test/smoke-port.test.ts
@@ -1,0 +1,61 @@
+import { createServer } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readPreferredSmokePort, resolveSmokeServerPort } from "../smoke/smoke-port.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolveClose) => {
+          server.close(() => {
+            resolveClose();
+          });
+        })
+    )
+  );
+  servers.length = 0;
+});
+
+describe("readPreferredSmokePort", () => {
+  it("returns a stable port for the same worktree and run id", () => {
+    const options = { worktreePath: "C:/worktrees/one", runId: 1234 };
+
+    expect(readPreferredSmokePort(options)).toBe(readPreferredSmokePort(options));
+  });
+
+  it("varies across different runs", () => {
+    const worktreePath = "C:/worktrees/one";
+
+    expect(readPreferredSmokePort({ worktreePath, runId: 1234 })).not.toBe(
+      readPreferredSmokePort({ worktreePath, runId: 1235 })
+    );
+  });
+});
+
+describe("resolveSmokeServerPort", () => {
+  it("falls back to another free port when the preferred one is busy", async () => {
+    const preferredPort = readPreferredSmokePort({ worktreePath: "C:/worktrees/two", runId: 7 });
+
+    await occupyPort(preferredPort);
+
+    await expect(
+      resolveSmokeServerPort({ worktreePath: "C:/worktrees/two", runId: 7, probeLimit: 1 })
+    ).resolves.not.toBe(preferredPort);
+  });
+});
+
+async function occupyPort(port: number) {
+  const server = createServer();
+
+  await new Promise<void>((resolveListen) => {
+    server.listen(port, "127.0.0.1", () => {
+      resolveListen();
+    });
+  });
+
+  servers.push(server);
+}


### PR DESCRIPTION
## Summary
- Keep smoke startup on a single worktree-scoped port across Playwright workers.
- Seed the smoke port from the repo root once and reuse it for both `baseURL` and the web server env.
- Preserve the existing web-player runtime path and avoid CLI changes.

## Validation
- `bun run smoke -- smoke/checkout-decision.diagram-canvas-overflow.spec.ts`
- `bun run lint`
- `bun run typecheck`

## Notes
- `bun.lock` was already dirty in the worktree and was intentionally left untouched.