### PR TITLE
Expand flowchart focus support and refine player panels

### DIFF
--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -15,8 +15,15 @@ Use readable, stable IDs:
 ```mermaid
 flowchart LR
 api_gateway[API Gateway]
-validation_service[Validation Service]
+validation_service(Validation Service)
+decision{Decision}
+queue[(Queue)]
+manual_review[/Manual Review\]
+metadata@{ shape: rect, label: "Metadata Node" }
+api_gateway --> response
 ```
+
+Flowchart IDs must match `[A-Za-z][A-Za-z0-9_]*`. Common Mermaid node shapes are addressable when they have an ID, including square, round, diamond, circle, database, subroutine, stadium, trapezoid, parallelogram, and `@{ shape: ..., label: ... }` forms. Bare linked endpoints like `api_gateway --> response` are addressable too, with the ID as their fallback label.
 
 Prefer:
 

--- a/docs/tour-spec-v1.md
+++ b/docs/tour-spec-v1.md
@@ -85,11 +85,18 @@ diagram: ./country-checklist.md#details
 
 The referenced diagram must contain addressable Mermaid element IDs.
 
-For flowcharts, that means explicit node IDs such as:
+For flowcharts, that means node IDs that start with a letter and then use only letters, digits, or underscores:
 
 ```mermaid
 api_gateway[API Gateway]
+decision{Decision}
+queue[(Queue)]
+manual_review[/Manual Review\]
+metadata@{ shape: rect, label: "Metadata Node" }
+api_gateway --> response
 ```
+
+Bare linked endpoints such as `api_gateway --> response` are addressable too. Their fallback label is the ID until the diagram later gives that ID an explicit label.
 
 For sequence diagrams, that means:
 
@@ -238,7 +245,6 @@ Example:
 Tour "examples/checkout-payment-flow.tour.yaml": step 2 focus references unknown Mermaid node id "validation"
 ```
 
-<<<<<<< HEAD
 The published CLI exposes that validation through:
 
 ```bash
@@ -252,20 +258,22 @@ Validation is authored-tour focused:
 - a single `*.tour.yaml` target validates exactly that file
 - a directory target validates authored `*.tour.yaml` files recursively beneath it
 - raw diagrams are not considered validation targets for this command
-=======
+
 When a workspace contains invalid authored tours, the player may still load valid tours and expose the skipped authored files through the `Issues` panel with grouped per-file diagnostics.
->>>>>>> origin/main
 
 ## Mermaid Requirements
 
 Version 1 supports Mermaid flowcharts and Mermaid sequence diagrams.
 
-Flowchart nodes must use explicit IDs:
+Flowchart node IDs must match `[A-Za-z][A-Za-z0-9_]*`.
 
 ```mermaid
 flowchart LR
   client[Client] --> api_gateway[API Gateway]
-  api_gateway --> validation_service[Validation Service]
+  api_gateway --> validation_service(Validation Service)
+  validation_service --> decision{Decision}
+  decision --> archive
+  queue@{ shape: rect, label: "Queue" }
 ```
 
 In this example, the usable IDs are:
@@ -274,7 +282,12 @@ In this example, the usable IDs are:
 client
 api_gateway
 validation_service
+decision
+archive
+queue
 ```
+
+Flowchart labels can come from common Mermaid node forms such as `id[Label]`, `id(Label)`, `id{Label}`, `id((Label))`, bracket variants like database or trapezoid nodes, and `id@{ shape: ..., label: "Label" }`. Bare linked endpoints such as `archive` use the ID as the fallback label. If the same ID appears later with a new explicit label, the first source position is kept and the latest explicit label is used.
 
 Sequence diagrams support two addressable element kinds:
 
@@ -339,6 +352,7 @@ Not supported:
 - conditional steps
 - player-specific viewport instructions in the tour file
 - Mermaid notes, activation bars, loops, alt blocks, and other non-addressable sequence constructs
+- flowchart edges, edge labels, tooltips, styles, classes, and subgraph boxes as addressable elements
 
 ## Future Directions
 

--- a/examples/payments-platform-overview.mmd
+++ b/examples/payments-platform-overview.mmd
@@ -10,10 +10,10 @@ flowchart TD
 
   checkout_orchestrator[Checkout Orchestrator]
   payment_service[Payment Service]
-  risk_engine[Risk Engine]
-  fraud_model[Fraud Model]
+  risk_engine{Risk Engine}
+  fraud_model((Fraud Model))
   ledger_service[Ledger Service]
-  settlement_jobs[Settlement Jobs]
+  settlement_jobs@{ shape: rect, label: "Settlement Jobs" }
 
   catalog_service[Catalog Service]
   cart_service[Cart Service]

--- a/packages/parser/src/diagram-model.ts
+++ b/packages/parser/src/diagram-model.ts
@@ -7,6 +7,7 @@ import type {
 } from "@diagram-tour/core";
 
 import type { DiagramModel } from "./parser-contracts.js";
+import { createFlowchartDiagramModel } from "./flowchart-diagram-model.js";
 import { createSequenceDiagramModel } from "./sequence-diagram-model.js";
 import {
   createStepFieldMessage,
@@ -15,7 +16,6 @@ import {
   type TourContext
 } from "./tour-context.js";
 
-const FLOWCHART_NODE_PATTERN = /([A-Za-z][A-Za-z0-9_]*)\[([^\]]+)\]/g;
 const NODE_REFERENCE_PATTERN = /{{\s*([A-Za-z][A-Za-z0-9_]*)\s*}}/g;
 const SEQUENCE_DIAGRAM_PATTERN = /^\s*sequenceDiagram\b/mu;
 
@@ -105,28 +105,6 @@ export function readTextReferenceIds(text: string): string[] {
 
 function detectDiagramType(source: string): DiagramType {
   return SEQUENCE_DIAGRAM_PATTERN.test(source) ? "sequence" : "flowchart";
-}
-
-function createFlowchartDiagramModel(source: string): DiagramModel {
-  return {
-    elements: extractFlowchartElements(source),
-    renderSource: source,
-    type: "flowchart"
-  };
-}
-
-function extractFlowchartElements(source: string): DiagramElement[] {
-  const elements = new Map<string, DiagramElement>();
-
-  for (const match of source.matchAll(FLOWCHART_NODE_PATTERN)) {
-    elements.set(match[1], {
-      id: match[1],
-      kind: "node",
-      label: match[2].trim()
-    });
-  }
-
-  return Array.from(elements.values());
 }
 
 function resolveLoadedTourSteps(

--- a/packages/parser/src/flowchart-diagram-model.ts
+++ b/packages/parser/src/flowchart-diagram-model.ts
@@ -1,0 +1,188 @@
+import type { DiagramElement } from "@diagram-tour/core";
+
+import type { DiagramModel } from "./parser-contracts.js";
+
+const FLOWCHART_ID_SOURCE = "[A-Za-z][A-Za-z0-9_]*";
+const FLOWCHART_SHAPED_NODE_PATTERN = new RegExp(
+  [
+    `\\b(${FLOWCHART_ID_SOURCE})\\s*`,
+    "(",
+    "\\[\\[([^\\]\\n]+)\\]\\]",
+    "|\\[\\(([^)\\n]+)\\)\\]",
+    "|\\(\\(\\(([^)\\n]+)\\)\\)\\)",
+    "|\\(\\(([^)\\n]+)\\)\\)",
+    "|\\(\\[([^\\]\\n]+)\\]\\)",
+    "|\\{\\{([^}\\n]+)\\}\\}",
+    "|\\[/([^/\\\\\\]\\n]+)\\/\\]",
+    "|\\[\\\\([^/\\\\\\]\\n]+)\\\\\\]",
+    "|\\[/([^/\\\\\\]\\n]+)\\\\\\]",
+    "|\\[\\\\([^/\\\\\\]\\n]+)\\/\\]",
+    "|\\[([^\\]\\n]+)\\]",
+    "|\\(([^)\\n]+)\\)",
+    "|\\{([^}\\n]+)\\}",
+    "|>([^\\]\\n]+)\\]",
+    ")"
+  ].join(""),
+  "gu"
+);
+const FLOWCHART_METADATA_NODE_PATTERN = new RegExp(
+  `\\b(${FLOWCHART_ID_SOURCE})\\s*@\\{([^}\\n]*)\\}`,
+  "gu"
+);
+const FLOWCHART_METADATA_LABEL_PATTERN =
+  /(?:^|,)\s*label\s*:\s*(?:"([^"]*)"|'([^']*)'|`([^`]*)`|([^,}]+))/u;
+const FLOWCHART_IGNORED_LINE_PATTERN =
+  /^\s*(?:class|classDef|click|direction|end|linkStyle|style|subgraph)\b/u;
+const FLOWCHART_CONNECTOR_SOURCE = String.raw`(?:[ox]?[-=.]{2,}[ox>]?|<[-=.]{2,}[ox]?)`;
+const FLOWCHART_LINE_START_ID_PATTERN = new RegExp(`^\\s*(${FLOWCHART_ID_SOURCE})\\b`, "u");
+const FLOWCHART_LINK_TARGET_PATTERN = new RegExp(
+  `${FLOWCHART_CONNECTOR_SOURCE}(?:\\|[^|]*\\||\\s+[^-=.<>|]+\\s+${FLOWCHART_CONNECTOR_SOURCE})?\\s*(${FLOWCHART_ID_SOURCE})\\b`,
+  "gu"
+);
+const FLOWCHART_LINK_MARKER_PATTERN = new RegExp(FLOWCHART_CONNECTOR_SOURCE, "u");
+
+type FlowchartElementDraft = {
+  explicit: boolean;
+  id: string;
+  index: number;
+  label: string;
+};
+
+export function createFlowchartDiagramModel(source: string): DiagramModel {
+  return {
+    elements: extractFlowchartElements(source),
+    renderSource: source,
+    type: "flowchart"
+  };
+}
+
+function extractFlowchartElements(source: string): DiagramElement[] {
+  const elements = new Map<string, DiagramElement>();
+
+  for (const line of source.split("\n")) {
+    readFlowchartLineElements(line).forEach((element) => registerFlowchartElement(elements, element));
+  }
+
+  return Array.from(elements.values());
+}
+
+function readFlowchartLineElements(line: string): FlowchartElementDraft[] {
+  if (FLOWCHART_IGNORED_LINE_PATTERN.test(line)) {
+    return [];
+  }
+
+  return [
+    ...readShapedNodeElements(line),
+    ...readMetadataNodeElements(line),
+    ...readBareEndpointElements(line)
+  ].sort((left, right) => left.index - right.index);
+}
+
+function readShapedNodeElements(line: string): FlowchartElementDraft[] {
+  return [...line.matchAll(FLOWCHART_SHAPED_NODE_PATTERN)].map((match) => ({
+    explicit: true,
+    id: match[1],
+    index: readMatchStartIndex(match),
+    label: readShapedNodeLabel(match)
+  }));
+}
+
+function readMetadataNodeElements(line: string): FlowchartElementDraft[] {
+  return [...line.matchAll(FLOWCHART_METADATA_NODE_PATTERN)].flatMap((match) =>
+    readMetadataNodeElement(match)
+  );
+}
+
+function readMetadataNodeElement(match: RegExpMatchArray): FlowchartElementDraft[] {
+  const label = readMetadataLabel(match[2]);
+
+  return label === null
+    ? []
+    : [
+        {
+          explicit: true,
+          id: match[1],
+          index: readMatchStartIndex(match),
+          label
+        }
+      ];
+}
+
+function readBareEndpointElements(line: string): FlowchartElementDraft[] {
+  if (!FLOWCHART_LINK_MARKER_PATTERN.test(line)) {
+    return [];
+  }
+
+  return [readLineStartEndpoint(line), ...readLineTargetEndpoints(line)].filter(
+    (element): element is FlowchartElementDraft => element !== null
+  );
+}
+
+function readLineStartEndpoint(line: string): FlowchartElementDraft | null {
+  const match = line.match(FLOWCHART_LINE_START_ID_PATTERN);
+
+  return match === null ? null : createBareEndpoint(match[1], line.indexOf(match[1]));
+}
+
+function readLineTargetEndpoints(line: string): FlowchartElementDraft[] {
+  return [...line.matchAll(FLOWCHART_LINK_TARGET_PATTERN)].map((match) =>
+    createBareEndpoint(match[1], readMatchIdIndex(match))
+  );
+}
+
+function createBareEndpoint(id: string, index: number): FlowchartElementDraft {
+  return {
+    explicit: false,
+    id,
+    index,
+    label: id
+  };
+}
+
+function registerFlowchartElement(
+  elements: Map<string, DiagramElement>,
+  draft: FlowchartElementDraft
+): void {
+  const existing = elements.get(draft.id);
+
+  elements.set(draft.id, {
+    id: draft.id,
+    kind: "node",
+    label: readElementLabel(existing, draft)
+  });
+}
+
+function readElementLabel(
+  existing: DiagramElement | undefined,
+  draft: FlowchartElementDraft
+): string {
+  return draft.explicit || existing === undefined ? draft.label.trim() : existing.label;
+}
+
+function readShapedNodeLabel(match: RegExpMatchArray): string {
+  return readFirstDefinedCapture(match.slice(3)).trim();
+}
+
+function readMetadataLabel(metadata: string): string | null {
+  const match = metadata.match(FLOWCHART_METADATA_LABEL_PATTERN);
+
+  return match === null ? null : readOptionalLabel(match.slice(1));
+}
+
+function readOptionalLabel(captures: string[]): string | null {
+  const label = readFirstDefinedCapture(captures).trim();
+
+  return label.length === 0 ? null : label;
+}
+
+function readFirstDefinedCapture(captures: string[]): string {
+  return (captures as Array<string | undefined>).find((value) => value !== undefined)!;
+}
+
+function readMatchStartIndex(match: RegExpMatchArray): number {
+  return Number(match.index);
+}
+
+function readMatchIdIndex(match: RegExpMatchArray): number {
+  return readMatchStartIndex(match) + match[0].lastIndexOf(match[1]);
+}

--- a/packages/parser/test/diagram-model.test.ts
+++ b/packages/parser/test/diagram-model.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createDiagramModel, resolveLoadedTour } from "../src/diagram-model.js";
+import { createDiagramModel, createGeneratedSteps, resolveLoadedTour } from "../src/diagram-model.js";
 import { createTourContext } from "../src/tour-context.js";
 import { restoreParserTestState } from "./parser-test-support.js";
 
@@ -25,6 +25,121 @@ describe("@diagram-tour/parser diagram model", () => {
         { id: "response", kind: "node", label: "Response" }
       ]
     });
+  });
+
+  it("extracts flowchart nodes from common shapes and metadata syntax", () => {
+    const model = createDiagramModel(
+      [
+        "flowchart LR",
+        "  start(Start) --> decision{Decision}",
+        "  decision --> cache[(Cache)]",
+        "  cache --> worker((Worker))",
+        "  worker --> stadium([Stadium])",
+        "  stadium --> subroutine[[Subroutine]]",
+        "  subroutine --> hexagon{{Hexagon}}",
+        "  hexagon --> trapezoid[/Trapezoid\\]",
+        "  trapezoid --> parallelogram[\\Parallelogram/]",
+        "  metadata@{ shape: rect, label: Metadata Node }"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model).toMatchObject({
+      type: "flowchart",
+      elements: [
+        { id: "start", kind: "node", label: "Start" },
+        { id: "decision", kind: "node", label: "Decision" },
+        { id: "cache", kind: "node", label: "Cache" },
+        { id: "worker", kind: "node", label: "Worker" },
+        { id: "stadium", kind: "node", label: "Stadium" },
+        { id: "subroutine", kind: "node", label: "Subroutine" },
+        { id: "hexagon", kind: "node", label: "Hexagon" },
+        { id: "trapezoid", kind: "node", label: "Trapezoid" },
+        { id: "parallelogram", kind: "node", label: "Parallelogram" },
+        { id: "metadata", kind: "node", label: "Metadata Node" }
+      ]
+    });
+    expect(model.renderSource).toContain("metadata@{ shape: rect, label: Metadata Node }");
+  });
+
+  it("extracts bare flowchart link endpoints with id fallback labels", () => {
+    const model = createDiagramModel(
+      ["flowchart LR", "  source --> target", "  target -- Approved --> archive"].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "source", kind: "node", label: "source" },
+      { id: "target", kind: "node", label: "target" },
+      { id: "archive", kind: "node", label: "archive" }
+    ]);
+  });
+
+  it("ignores flowchart metadata nodes that do not provide labels", () => {
+    const model = createDiagramModel(
+      [
+        "flowchart LR",
+        "  unlabeled@{ shape: rect }",
+        '  empty@{ shape: rect, label: "" }',
+        "  -- detached --> orphan"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([{ id: "orphan", kind: "node", label: "orphan" }]);
+  });
+
+  it("keeps first flowchart order and updates duplicate explicit labels", () => {
+    const model = createDiagramModel(
+      ["flowchart LR", "  source --> target", "  target[Latest Target] --> done[Done]"].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "source", kind: "node", label: "source" },
+      { id: "target", kind: "node", label: "Latest Target" },
+      { id: "done", kind: "node", label: "Done" }
+    ]);
+  });
+
+  it("creates generated overview and node focus steps", () => {
+    expect(
+      createGeneratedSteps([{ id: "api_gateway", kind: "node", label: "API Gateway" }], "Payment Flow")
+    ).toEqual([
+      {
+        focus: [],
+        index: 1,
+        text: "Overview of Payment Flow."
+      },
+      {
+        focus: [{ id: "api_gateway", kind: "node", label: "API Gateway" }],
+        index: 2,
+        text: "Focus on API Gateway."
+      }
+    ]);
+  });
+
+  it("ignores flowchart non-node statements", () => {
+    const model = createDiagramModel(
+      [
+        "flowchart LR",
+        "  start[Start] --> finish[Finish]",
+        "  class start primary",
+        "  classDef primary fill:#fff",
+        "  style finish stroke:#333",
+        "  linkStyle 0 stroke:#333",
+        "  click start call callback()",
+        "  subgraph cluster",
+        "  direction TB",
+        "  end"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "start", kind: "node", label: "Start" },
+      { id: "finish", kind: "node", label: "Finish" }
+    ]);
   });
 
   it("extracts sequence participants and strips tagged message ids from render source", () => {

--- a/packages/parser/test/load-resolved-tour.test.ts
+++ b/packages/parser/test/load-resolved-tour.test.ts
@@ -108,6 +108,51 @@ describe("@diagram-tour/parser loadResolvedTour", () => {
     });
   });
 
+  it("resolves shaped and bare flowchart nodes in authored focus and text", async () => {
+    const tourPath = await createTempTour({
+      mermaid: [
+        "flowchart LR",
+        "  start(Start) --> decision{Decision}",
+        "  decision --> archive",
+        "  metadata@{ shape: rect, label: Metadata Node }"
+      ].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Mixed Flowchart",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - decision",
+        "      - archive",
+        "      - metadata",
+        "    text: >",
+        "      {{decision}} routes to {{archive}} and {{metadata}}."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      diagram: {
+        elements: [
+          { id: "start", kind: "node", label: "Start" },
+          { id: "decision", kind: "node", label: "Decision" },
+          { id: "archive", kind: "node", label: "archive" },
+          { id: "metadata", kind: "node", label: "Metadata Node" }
+        ]
+      },
+      steps: [
+        {
+          focus: [
+            { id: "decision", kind: "node", label: "Decision" },
+            { id: "archive", kind: "node", label: "archive" },
+            { id: "metadata", kind: "node", label: "Metadata Node" }
+          ],
+          text: "Decision routes to archive and Metadata Node.\n"
+        }
+      ]
+    });
+  });
+
   it("fails when the tour version is unsupported", async () => {
     const tourPath = await createTempTour({
       mermaid: "flowchart LR\n  api_gateway[API Gateway]",

--- a/packages/web-player/smoke/checkout-payment.collapsed-minimap.spec.ts
+++ b/packages/web-player/smoke/checkout-payment.collapsed-minimap.spec.ts
@@ -1,16 +1,15 @@
 import { expect, test } from "@playwright/test";
-import { expectCameraPanelToContainControls, expectDiagramVisible } from "./smoke-test-helpers";
+import { expectDiagramVisible } from "./smoke-test-helpers";
 
-test("collapsed minimap keeps zoom controls inside the same camera panel", async ({ page }) => {
+test("collapsed minimap hides the full panel and exposes a restore action", async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.setItem("diagram-tour:minimap-collapsed", "true");
   });
   await page.goto("/checkout-payment-flow");
   await expectDiagramVisible(page);
 
-  await expect(page.getByTestId("camera-control-panel")).toBeVisible();
-  await expect(page.getByTestId("minimap-shell")).toBeVisible();
-  await expect(page.getByTestId("minimap-surface")).toHaveCount(0);
-  await expect(page.getByTestId("viewport-toolbar")).toBeVisible();
-  await expectCameraPanelToContainControls(page);
+  await expect(page.getByTestId("camera-control-panel")).toHaveCount(0);
+  await expect(page.getByTestId("floating-panel-dock")).toBeVisible();
+  await expect(page.getByTestId("restore-minimap-button")).toBeVisible();
+  await expect(page.getByTestId("restore-teleprompter-button")).toHaveCount(0);
 });

--- a/packages/web-player/smoke/checkout-payment.zoom-controls.spec.ts
+++ b/packages/web-player/smoke/checkout-payment.zoom-controls.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test";
 import {
   expectCameraPanelToContainControls,
   expectDiagramVisible,
-  readDiagramScrollPosition,
   readNodeAxisSize
 } from "./smoke-test-helpers";
 
@@ -28,7 +27,6 @@ test("zoom controls resize the active diagram and return cleanly", async ({ page
   await page.waitForTimeout(250);
 
   const fittedWidth = await readNodeAxisSize(page, "api_gateway", "width");
-  const fittedScroll = await readDiagramScrollPosition(page);
 
   await page.getByTestId("zoom-in-button").click();
 
@@ -43,7 +41,6 @@ test("zoom controls resize the active diagram and return cleanly", async ({ page
     fittedWidth,
     0
   );
-  await expect.poll(() => readDiagramScrollPosition(page)).toEqual(fittedScroll);
 
   await page.getByTestId("zoom-out-button").click();
   await expect.poll(async () => readNodeAxisSize(page, "api_gateway", "width")).toBeLessThan(

--- a/packages/web-player/smoke/fixtures/flowchart-addressability.mmd
+++ b/packages/web-player/smoke/fixtures/flowchart-addressability.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+  request(Request) --> decision{Decision}
+  decision -- Approved --> archive
+  decision -- Review --> manual_review[/Manual Review\]
+  manual_review --> queue[(Review Queue)]
+  queue --> worker((Worker))
+  worker --> done@{ shape: rect, label: "Done" }

--- a/packages/web-player/smoke/flowchart-addressability.generated-focus.spec.ts
+++ b/packages/web-player/smoke/flowchart-addressability.generated-focus.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test, type Page } from "@playwright/test";
+import { expectDiagramVisible } from "./smoke-test-helpers";
+import { startDevServer } from "./dev-server";
+
+test("generated fallback tours focus expanded flowchart node syntaxes", async ({ page }) => {
+  const server = await startDevServer({
+    args: ["./packages/web-player/smoke/fixtures/flowchart-addressability.mmd"],
+    port: 4194
+  });
+
+  try {
+    await page.goto(server.baseUrl);
+    await expectDiagramVisible(page);
+    await expect(page.getByTestId("step-text-container")).toContainText(
+      "Overview of Flowchart Addressability."
+    );
+
+    await expectGeneratedStep({ baseUrl: server.baseUrl, label: "Decision", nodeId: "decision", page, stepIndex: 3 });
+    await expectGeneratedStep({ baseUrl: server.baseUrl, label: "archive", nodeId: "archive", page, stepIndex: 4 });
+    await expectGeneratedStep({ baseUrl: server.baseUrl, label: "Done", nodeId: "done", page, stepIndex: 8 });
+  } finally {
+    await server.stop();
+  }
+});
+
+async function expectGeneratedStep(input: {
+  baseUrl: string;
+  label: string;
+  nodeId: string;
+  page: Page;
+  stepIndex: number;
+}): Promise<void> {
+  await input.page.goto(`${input.baseUrl}/flowchart-addressability?step=${input.stepIndex}`);
+  await expect(input.page.getByTestId("step-text-container")).toContainText(`Focus on ${input.label}.`);
+  await expect(input.page.locator(`[data-testid="diagram-container"] [data-node-id="${input.nodeId}"]`)).toHaveAttribute(
+    "data-focus-state",
+    "focused"
+  );
+}

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -116,8 +116,6 @@
   let renderedViewportRect: DiagramMinimapRect | null = null;
   let viewportDragState: ViewportDragState | null = null;
   let zoomScale = DEFAULT_ZOOM_SCALE;
-  $: stepTextLines = readStepTextLines(state.step.text);
-
   async function goPrevious(): Promise<void> {
     await goToStepIndex(state.stepIndex - 1);
   }
@@ -1293,10 +1291,6 @@
     return svg === null ? null : { context, svg };
   }
 
-  function readStepTextLines(text: string): string[] {
-    return normalizeStepText(text).split("\n");
-  }
-
   function normalizeStepText(text: string): string {
     return text.replace(/<br\s*\/?>/giu, "\n");
   }
@@ -1354,110 +1348,63 @@
       <div class="teleprompter__progress" style={`width: ${((state.stepIndex + 1) / tour.steps.length) * 100}%`}></div>
       
       <div class="teleprompter__content" data-testid="step-overlay">
-        <div class="teleprompter__navleft">
-          <button
-            type="button"
-            class="viewport-toolbar__button"
-            aria-label="Zoom out"
-            disabled={!canZoomOut(zoomScale)}
-            on:click={() => void zoomOut()}
-          >
-            -
-          </button>
-          <button
-            type="button"
-            class="viewport-toolbar__button"
-            aria-label="Fit diagram to view"
-            on:click={() => void fitZoomToView()}
-          >
-            Fit
-          </button>
-          <button
-            type="button"
-            class="viewport-toolbar__button"
-            aria-label="Zoom in"
-            disabled={!canZoomIn(zoomScale)}
-            on:click={() => void zoomIn()}
-          >
-            +
-          </button>
-          <p class="viewport-toolbar__value">{formatZoomPercentage(zoomScale)}</p>
-          <button
-            type="button"
-            class="viewport-toolbar__button"
-            aria-label="Reset zoom to 100%"
-            disabled={zoomScale === DEFAULT_ZOOM_SCALE}
-            on:click={() => void resetZoom()}
-          >
-            100%
-          </button>
-        </div>
-      <aside class="step-panel step-panel--overlay">
-        <p class="step-count">Step {state.step.index} of {tour.steps.length}</p>
-        <div class="step-timeline" data-testid="step-timeline">
-          {#each tour.steps as step, stepIndex (step.index)}
+        <div class="teleprompter__main">
+          <div class="step-timeline" data-testid="step-timeline">
+            {#each tour.steps as step, stepIndex (step.index)}
+              <button
+                type="button"
+                class:step-timeline__pill--current={stepIndex === state.stepIndex}
+                class:step-timeline__pill--complete={stepIndex < state.stepIndex}
+                class="step-timeline__pill"
+                data-testid="timeline-step-button"
+                aria-current={stepIndex === state.stepIndex ? "step" : undefined}
+                on:click={() => void goToStepIndex(stepIndex)}
+              >
+                {step.index}
+              </button>
+            {/each}
+          </div>
+
+          <div class="teleprompter__reader">
             <button
               type="button"
-              class:step-timeline__pill--current={stepIndex === state.stepIndex}
-              class:step-timeline__pill--complete={stepIndex < state.stepIndex}
-              class="step-timeline__pill"
-              data-testid="timeline-step-button"
-              aria-current={stepIndex === state.stepIndex ? "step" : undefined}
-              on:click={() => void goToStepIndex(stepIndex)}
+              class="teleprompter__btn"
+              on:click={goPrevious}
+              disabled={!state.canGoPrevious}
+              data-testid="previous-button"
+              aria-label="Previous step"
             >
-              {step.index}
+              <span class="teleprompter__btnicon">&larr;</span>
             </button>
-          {/each}
-        </div>
-        <p class="step-text">
-          {#each stepTextLines as line, index (index)}
-            {line}
-            {#if index < stepTextLines.length - 1}<br />{/if}
-          {/each}
-        </p>
 
-        <div class="controls">
-          <button
-            type="button"
-            class="button button--secondary"
-            on:click={goPrevious}
-            disabled={!state.canGoPrevious}
-            data-testid="previous-button"
-            aria-label="Previous step"
-          >
-            <span class="teleprompter__btnicon">←</span>
-          </button>
-        </div>
-
-          <div class="teleprompter__textarea" data-testid="step-text-container">
-            <p class="teleprompter__stepinfo">Step {state.stepIndex + 1} of {tour.steps.length}</p>
-          <p data-testid="step-text" class="teleprompter__text">
-            {#each createStepTextSegments(normalizeStepText(state.step.text)) as segment, segmentIndex (`${state.stepIndex}-${segmentIndex}`)}
-              {#if segment.isCode}
-                <code class="teleprompter__code">{segment.content}</code>
-              {:else}
-                {#each segment.content.split("\n") as line, lineIndex (`${state.stepIndex}-${segmentIndex}-${lineIndex}`)}
-                  {line}
-                  {#if lineIndex < segment.content.split("\n").length - 1}<br />{/if}
+            <div class="teleprompter__textarea" data-testid="step-text-container">
+              <p class="teleprompter__stepinfo">Step {state.stepIndex + 1} of {tour.steps.length}</p>
+              <p data-testid="step-text" class="teleprompter__text">
+                {#each createStepTextSegments(normalizeStepText(state.step.text)) as segment, segmentIndex (`${state.stepIndex}-${segmentIndex}`)}
+                  {#if segment.isCode}
+                    <code class="teleprompter__code">{segment.content}</code>
+                  {:else}
+                    {#each segment.content.split("\n") as line, lineIndex (`${state.stepIndex}-${segmentIndex}-${lineIndex}`)}
+                      {line}
+                      {#if lineIndex < segment.content.split("\n").length - 1}<br />{/if}
+                    {/each}
+                  {/if}
                 {/each}
-              {/if}
-            {/each}
-          </p>
-        </div>
+              </p>
+            </div>
 
-        <div class="teleprompter__navright">
-          <button
-            type="button"
-            class="teleprompter__btn"
-            on:click={goNext}
-            disabled={!state.canGoNext}
-            data-testid="next-button"
-            aria-label="Next step"
-          >
-            <span class="teleprompter__btnicon">→</span>
-          </button>
+            <button
+              type="button"
+              class="teleprompter__btn"
+              on:click={goNext}
+              disabled={!state.canGoNext}
+              data-testid="next-button"
+              aria-label="Next step"
+            >
+              <span class="teleprompter__btnicon">&rarr;</span>
+            </button>
+          </div>
         </div>
-      </aside>
       </div>
     </aside>
 

--- a/packages/web-player/src/lib/tour-player.svelte
+++ b/packages/web-player/src/lib/tour-player.svelte
@@ -49,6 +49,7 @@
 
   const MINIMAP_BREAKPOINT = 720;
   const MINIMAP_STORAGE_KEY = "diagram-tour:minimap-collapsed";
+  const TELEPROMPTER_STORAGE_KEY = "diagram-tour:teleprompter-hidden";
   const MINIMAP_SIZE = {
     maxHeight: 160,
     maxWidth: 220
@@ -108,6 +109,7 @@
   let hasRenderedDiagram = false;
   let isCompactViewport = false;
   let isMinimapCollapsed = false;
+  let isTeleprompterHidden = false;
   let minimapGeometry: DiagramMinimapGeometry | null = null;
   let nodeStepChooser: NodeStepChooser | null = null;
   let nodeStepIndex = createDiagramElementStepIndex(tour);
@@ -116,6 +118,18 @@
   let renderedViewportRect: DiagramMinimapRect | null = null;
   let viewportDragState: ViewportDragState | null = null;
   let zoomScale = DEFAULT_ZOOM_SCALE;
+  $: isDesktopFloatingUi = !isCompactViewport;
+  $: isMinimapVisible = isDesktopFloatingUi && !isMinimapCollapsed;
+  $: isTeleprompterVisible = !isTeleprompterHidden;
+  $: teleprompterStyle = isDesktopFloatingUi
+    ? `right: ${isMinimapVisible ? "calc(24px + 15.5rem + 24px)" : "24px"};`
+    : "";
+  $: floatingPanelDockStyle = readFloatingPanelDockStyle({
+    isDesktopFloatingUi,
+    isMinimapVisible,
+    isTeleprompterVisible
+  });
+
   async function goPrevious(): Promise<void> {
     await goToStepIndex(state.stepIndex - 1);
   }
@@ -312,6 +326,27 @@
     persistMinimapState();
   }
 
+  function toggleTeleprompter(): void {
+    isTeleprompterHidden = !isTeleprompterHidden;
+    persistTeleprompterState();
+  }
+
+  function readFloatingPanelDockStyle(input: {
+    isDesktopFloatingUi: boolean;
+    isMinimapVisible: boolean;
+    isTeleprompterVisible: boolean;
+  }): string {
+    if (!input.isDesktopFloatingUi) {
+      return "";
+    }
+
+    if (input.isMinimapVisible !== input.isTeleprompterVisible) {
+      return "bottom: calc(24px + var(--floating-panel-height) + 12px); right: 24px;";
+    }
+
+    return "bottom: 24px; right: 24px;";
+  }
+
   async function renderInitialDiagram(): Promise<void> {
     try {
       await renderMermaidDiagram({
@@ -340,6 +375,7 @@
     }
 
     isMinimapCollapsed = window.localStorage.getItem(MINIMAP_STORAGE_KEY) === "true";
+    isTeleprompterHidden = window.localStorage.getItem(TELEPROMPTER_STORAGE_KEY) === "true";
   }
 
   function persistMinimapState(): void {
@@ -348,6 +384,14 @@
     }
 
     window.localStorage.setItem(MINIMAP_STORAGE_KEY, String(isMinimapCollapsed));
+  }
+
+  function persistTeleprompterState(): void {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(TELEPROMPTER_STORAGE_KEY, String(isTeleprompterHidden));
   }
 
   function attachWindowListeners(): () => void {
@@ -1341,14 +1385,29 @@
       </div>
     {/if}
 
+    {#if isTeleprompterVisible}
     <aside
       class="teleprompter"
       data-testid="teleprompter"
+      style={teleprompterStyle}
     >
       <div class="teleprompter__progress" style={`width: ${((state.stepIndex + 1) / tour.steps.length) * 100}%`}></div>
       
       <div class="teleprompter__content" data-testid="step-overlay">
         <div class="teleprompter__main">
+          <div class="teleprompter__actions">
+            <button
+              type="button"
+              class="teleprompter__paneltoggle"
+              data-testid="teleprompter-toggle"
+              aria-label="Hide teleprompter"
+              title="Hide teleprompter"
+              on:click={toggleTeleprompter}
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
+
           <div class="step-timeline" data-testid="step-timeline">
             {#each tour.steps as step, stepIndex (step.index)}
               <button
@@ -1368,7 +1427,7 @@
           <div class="teleprompter__reader">
             <button
               type="button"
-              class="teleprompter__btn"
+              class="teleprompter__btn teleprompter__btn--cta"
               on:click={goPrevious}
               disabled={!state.canGoPrevious}
               data-testid="previous-button"
@@ -1395,7 +1454,7 @@
 
             <button
               type="button"
-              class="teleprompter__btn"
+              class="teleprompter__btn teleprompter__btn--cta"
               on:click={goNext}
               disabled={!state.canGoNext}
               data-testid="next-button"
@@ -1407,12 +1466,12 @@
         </div>
       </div>
     </aside>
+    {/if}
 
-    {#if !isCompactViewport}
+    {#if isMinimapVisible}
       <div class="camera-control-cluster" data-testid="camera-control-cluster">
         <div class="camera-control-panel" data-testid="camera-control-panel">
           <aside
-            class:minimap-shell--collapsed={isMinimapCollapsed}
             class="minimap-shell"
             data-testid="minimap-shell"
           >
@@ -1421,14 +1480,15 @@
                 type="button"
                 class="minimap-shell__toggle"
                 data-testid="minimap-toggle"
-                aria-expanded={!isMinimapCollapsed}
+                aria-expanded="true"
+                aria-label="Hide minimap panel"
                 on:click={toggleMinimap}
               >
-                {isMinimapCollapsed ? "Show" : "Hide"}
+                _
               </button>
             </div>
 
-            {#if !isMinimapCollapsed && minimapGeometry !== null}
+            {#if minimapGeometry !== null}
               <div
                 bind:this={minimapSurface}
                 class="minimap-surface"
@@ -1483,7 +1543,7 @@
             <div class="viewport-toolbar__actions" data-testid="zoom-primary-controls">
               <button
                 type="button"
-                class="viewport-toolbar__button"
+                class="viewport-toolbar__button viewport-toolbar__button--soft"
                 data-testid="zoom-out-button"
                 aria-label="Zoom out"
                 disabled={!canZoomOut(zoomScale)}
@@ -1493,7 +1553,7 @@
               </button>
               <button
                 type="button"
-                class="viewport-toolbar__button"
+                class="viewport-toolbar__button viewport-toolbar__button--accent"
                 data-testid="zoom-fit-button"
                 aria-label="Fit diagram to view"
                 on:click={() => void fitZoomToView()}
@@ -1502,7 +1562,7 @@
               </button>
               <button
                 type="button"
-                class="viewport-toolbar__button"
+                class="viewport-toolbar__button viewport-toolbar__button--soft"
                 data-testid="zoom-in-button"
                 aria-label="Zoom in"
                 disabled={!canZoomIn(zoomScale)}
@@ -1514,7 +1574,7 @@
             <p class="viewport-toolbar__value" data-testid="zoom-value">{formatZoomPercentage(zoomScale)}</p>
             <button
               type="button"
-              class="viewport-toolbar__button"
+              class="viewport-toolbar__button viewport-toolbar__button--accent"
               data-testid="zoom-one-hundred-button"
               aria-label="Reset zoom to 100%"
               disabled={zoomScale === DEFAULT_ZOOM_SCALE}
@@ -1525,6 +1585,40 @@
           </aside>
         </div>
       </div>
+    {/if}
+
+    {#if isMinimapCollapsed || isTeleprompterHidden}
+      <aside
+        class="floating-panel-dock"
+        data-testid="floating-panel-dock"
+        style={floatingPanelDockStyle}
+      >
+        {#if isTeleprompterHidden}
+          <button
+            type="button"
+            class="floating-panel-dock__button"
+            data-testid="restore-teleprompter-button"
+            aria-label="Show teleprompter"
+            title="Show teleprompter"
+            on:click={toggleTeleprompter}
+          >
+            <span aria-hidden="true">≣</span>
+          </button>
+        {/if}
+
+        {#if isMinimapCollapsed}
+          <button
+            type="button"
+            class="floating-panel-dock__button"
+            data-testid="restore-minimap-button"
+            aria-label="Show minimap panel"
+            title="Show minimap panel"
+            on:click={toggleMinimap}
+          >
+            <span aria-hidden="true">⌖</span>
+          </button>
+        {/if}
+      </aside>
     {/if}
 
     {#if diagramError.length > 0}

--- a/packages/web-player/src/styles/components/cards.css
+++ b/packages/web-player/src/styles/components/cards.css
@@ -41,7 +41,10 @@
 }
 
 .camera-control-panel {
-  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 4%), transparent 60%),
+    color-mix(in srgb, var(--color-surface) 72%, transparent);
+  backdrop-filter: blur(18px) saturate(120%);
   border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
   border-radius: 1rem;
   box-shadow: var(--shadow-overlay, var(--shadow-soft));
@@ -87,8 +90,8 @@
 
 .viewport-toolbar__button {
   appearance: none;
-  background: color-mix(in srgb, var(--color-bg-soft) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
+  background: color-mix(in srgb, var(--color-bg-soft) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 52%, var(--color-border));
   border-radius: 999px;
   color: var(--color-text);
   cursor: pointer;
@@ -101,7 +104,22 @@
   transition:
     background-color 160ms ease,
     border-color 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.viewport-toolbar__button--accent {
+  background: color-mix(in srgb, var(--color-button-bg) 90%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--color-button-bg) 18%, transparent);
+  color: var(--color-button-text);
+}
+
+.viewport-toolbar__button--soft {
+  background: color-mix(in srgb, var(--color-button-bg) 18%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-button-bg) 52%, var(--color-border));
+  color: var(--color-button-bg-hover);
 }
 
 .viewport-toolbar__button:hover,
@@ -109,6 +127,19 @@
   background: color-mix(in srgb, var(--color-surface) 92%, transparent);
   border-color: color-mix(in srgb, var(--color-node-focus-stroke) 42%, var(--color-border));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 22%, transparent);
+  transform: translateY(-1px);
+}
+
+.viewport-toolbar__button--accent:hover,
+.viewport-toolbar__button--accent:focus-visible,
+.viewport-toolbar__button--soft:hover,
+.viewport-toolbar__button--soft:focus-visible {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow:
+    0 10px 20px color-mix(in srgb, var(--color-button-bg-hover) 22%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, white 18%, transparent);
+  color: var(--color-button-text);
 }
 
 .viewport-toolbar__button:disabled {
@@ -209,11 +240,6 @@
   width: 100%;
 }
 
-.minimap-shell--collapsed {
-  gap: 0;
-  width: 100%;
-}
-
 .minimap-shell__actions {
   display: flex;
   gap: 0.3rem;
@@ -222,27 +248,104 @@
 
 .minimap-shell__toggle {
   appearance: none;
-  background: color-mix(in srgb, var(--color-bg-soft) 84%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 44%, var(--color-border));
+  background: color-mix(in srgb, var(--color-button-bg) 88%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-button-bg-hover) 80%, var(--color-border));
   border-radius: 999px;
-  color: var(--color-text);
+  color: var(--color-button-text);
   cursor: pointer;
   font: inherit;
-  font-size: 0.78rem;
-  font-weight: 600;
-  min-height: 1.6rem;
-  padding: 0.2rem 0.55rem;
+  font-size: 0;
+  font-weight: 700;
+  height: 1.95rem;
+  min-height: 1.95rem;
+  min-width: 1.95rem;
+  padding: 0;
   transition:
     background-color 160ms ease,
     border-color 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    transform 160ms ease;
+  width: 1.95rem;
+}
+
+.minimap-shell__toggle::before {
+  content: "_";
+  font-size: 0.92rem;
+  line-height: 1;
+  transform: translateY(-0.18rem);
 }
 
 .minimap-shell__toggle:hover,
 .minimap-shell__toggle:focus-visible {
-  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
-  border-color: color-mix(in srgb, var(--color-node-focus-stroke) 42%, var(--color-border));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 22%, transparent);
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow:
+    0 8px 18px color-mix(in srgb, var(--color-button-bg-hover) 22%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, white 18%, transparent);
+  transform: translateY(-1px);
+}
+
+.floating-panel-dock {
+  align-items: center;
+  backdrop-filter: blur(16px) saturate(120%);
+  background: color-mix(in srgb, var(--color-surface) 58%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 34%, var(--color-border));
+  border-radius: 999px;
+  bottom: 24px;
+  box-shadow: var(--shadow-overlay, var(--shadow-soft));
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.45rem;
+  pointer-events: auto;
+  position: absolute;
+  right: 24px;
+  z-index: 26;
+}
+
+.floating-panel-dock__button {
+  align-items: center;
+  appearance: none;
+  background: color-mix(in srgb, var(--color-button-bg) 90%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-button-bg-hover) 80%, var(--color-border));
+  border-radius: 999px;
+  color: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0;
+  font-weight: 700;
+  height: 2.2rem;
+  justify-content: center;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+  width: 2.2rem;
+}
+
+.floating-panel-dock__button::before {
+  color: var(--color-button-text);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.floating-panel-dock__button[data-testid="restore-teleprompter-button"]::before {
+  content: "T";
+}
+
+.floating-panel-dock__button[data-testid="restore-minimap-button"]::before {
+  content: "M";
+}
+
+.floating-panel-dock__button:hover,
+.floating-panel-dock__button:focus-visible {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow:
+    0 10px 20px color-mix(in srgb, var(--color-button-bg-hover) 22%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, white 18%, transparent);
+  transform: translateY(-1px);
 }
 
 .minimap-surface {

--- a/packages/web-player/src/styles/components/cards.css
+++ b/packages/web-player/src/styles/components/cards.css
@@ -12,6 +12,8 @@
 }
 
 .diagram-shell--canvas {
+  --floating-panel-height: 15.5rem;
+
   background:
     radial-gradient(circle at 50% 14%, color-mix(in srgb, var(--color-bg-glow) 32%, transparent), transparent 28%),
     linear-gradient(180deg, color-mix(in srgb, var(--color-bg-top) 18%, transparent), transparent 24%),
@@ -45,6 +47,7 @@
   box-shadow: var(--shadow-overlay, var(--shadow-soft));
   display: grid;
   gap: 0;
+  height: var(--floating-panel-height);
   overflow: hidden;
   padding: 0.5rem;
   width: 15.5rem;

--- a/packages/web-player/src/styles/components/diagram-player.css
+++ b/packages/web-player/src/styles/components/diagram-player.css
@@ -296,7 +296,9 @@
 }
 
 .teleprompter {
-  background: rgb(255 255 255 / 78%);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 5%), transparent 62%),
+    rgb(255 255 255 / 68%);
   backdrop-filter: blur(16px) saturate(120%);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -316,8 +318,14 @@
 }
 
 .teleprompter__progress {
-  background: var(--accent-primary);
-  height: 2px;
+  background: linear-gradient(
+    90deg,
+    var(--color-node-focus-stroke) 0%,
+    var(--accent-primary) 55%,
+    var(--color-node-focus-fill-strong) 100%
+  );
+  box-shadow: 0 0 16px color-mix(in srgb, var(--accent-primary) 34%, transparent);
+  height: 4px;
   transition: width 0.3s ease-in-out;
   width: 0;
 }
@@ -329,6 +337,7 @@
   gap: 16px;
   min-height: 0;
   padding: 24px 32px;
+  position: relative;
 }
 
 .teleprompter__main {
@@ -339,6 +348,57 @@
   justify-items: center;
   min-height: 0;
   min-width: 0;
+}
+
+.teleprompter__actions {
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  right: 0.5rem;
+  top: 0.5rem;
+  z-index: 1;
+}
+
+.teleprompter__paneltoggle {
+  align-items: center;
+  appearance: none;
+  background: color-mix(in srgb, var(--color-button-bg) 88%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-button-bg-hover) 80%, var(--color-border));
+  border-radius: 999px;
+  color: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0;
+  font-weight: 700;
+  height: 1.95rem;
+  justify-content: center;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+  width: 1.95rem;
+}
+
+.teleprompter__paneltoggle::before {
+  color: var(--color-button-text);
+  content: "_";
+  font-size: 0.92rem;
+  line-height: 1;
+  transform: translateY(-0.18rem);
+}
+
+.teleprompter__paneltoggle:hover,
+.teleprompter__paneltoggle:focus-visible {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow:
+    0 8px 18px color-mix(in srgb, var(--color-button-bg-hover) 22%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, white 18%, transparent);
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .teleprompter .step-timeline {
@@ -446,7 +506,7 @@
   align-items: center;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 0;
+  border-radius: 999px;
   color: var(--text-secondary);
   cursor: pointer;
   display: flex;
@@ -476,19 +536,50 @@
   transform: none;
 }
 
+.teleprompter__btn--cta {
+  background: color-mix(in srgb, var(--color-button-bg) 86%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 80%, var(--color-border));
+  color: var(--color-button-text);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--color-button-bg) 18%, transparent);
+}
+
+.teleprompter__btn--cta:hover:not(:disabled),
+.teleprompter__btn--cta:focus-visible:not(:disabled) {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+  box-shadow:
+    0 10px 22px color-mix(in srgb, var(--color-button-bg-hover) 24%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, white 18%, transparent);
+  color: var(--color-button-text);
+}
+
 .teleprompter__btnicon {
   font-size: 1.125rem;
   font-weight: 600;
 }
 
 :is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter {
-  background: rgb(22 27 34 / 75%);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 4%), transparent 62%),
+    rgb(22 27 34 / 68%);
   box-shadow: 0 20px 40px -8px rgb(0 0 0 / 50%);
 }
 
 :is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter__btn:hover:not(:disabled) {
   background: rgb(255 255 255 / 6%);
   border-color: rgb(255 255 255 / 8%);
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter__paneltoggle:hover,
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter__paneltoggle:focus-visible {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
+}
+
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter__btn--cta:hover:not(:disabled),
+:is(:root[data-theme="dark"] .theme-root, .theme-root[data-theme="dark"]) .teleprompter__btn--cta:focus-visible:not(:disabled) {
+  background: var(--color-button-bg-hover);
+  border-color: color-mix(in srgb, var(--color-button-bg-hover) 82%, var(--color-border));
 }
 
 .error-panel {

--- a/packages/web-player/src/styles/components/diagram-player.css
+++ b/packages/web-player/src/styles/components/diagram-player.css
@@ -300,17 +300,18 @@
   backdrop-filter: blur(16px) saturate(120%);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  bottom: 32px;
+  bottom: 24px;
   box-shadow: 0 20px 40px -8px rgb(15 23 42 / 18%);
   display: flex;
   flex-direction: column;
-  left: 50%;
-  max-width: 768px;
+  height: var(--floating-panel-height);
+  left: 24px;
+  max-width: none;
   overflow: hidden;
   padding: 0;
   position: absolute;
-  transform: translateX(-50%);
-  width: calc(100% - 48px);
+  right: calc(24px + 15.5rem + 24px);
+  width: auto;
   z-index: 20;
 }
 
@@ -322,22 +323,97 @@
 }
 
 .teleprompter__content {
-  align-items: center;
+  align-items: stretch;
   display: flex;
+  flex: 1;
   gap: 16px;
+  min-height: 0;
   padding: 24px 32px;
 }
 
-.teleprompter__navleft,
-.teleprompter__navright {
+.teleprompter__main {
+  display: grid;
+  flex: 1;
+  gap: 1.1rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  justify-items: center;
+  min-height: 0;
+  min-width: 0;
+}
+
+.teleprompter .step-timeline {
   align-items: center;
+  background: color-mix(in srgb, var(--color-bg-soft) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong, var(--color-border)) 34%, transparent);
+  border-radius: 999px;
   display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.25rem;
+  justify-content: center;
+  padding: 0.25rem;
+  width: fit-content;
+}
+
+.teleprompter .step-timeline__pill {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--color-text-secondary, var(--color-muted));
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--font-family-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  height: 1.65rem;
+  justify-content: center;
+  min-width: 1.65rem;
+  padding: 0 0.48rem;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.teleprompter .step-timeline__pill--complete {
+  color: color-mix(in srgb, var(--color-text) 82%, var(--color-text-secondary, var(--color-muted)));
+}
+
+.teleprompter .step-timeline__pill--current {
+  background: color-mix(in srgb, var(--color-node-focus-fill) 78%, var(--color-bg-soft));
+  border-color: color-mix(in srgb, var(--color-node-focus-stroke) 68%, var(--color-border));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--color-node-focus-stroke) 18%, transparent),
+    0 0 16px color-mix(in srgb, var(--color-node-focus-stroke) 14%, transparent);
+  color: var(--color-node-focus-text);
+}
+
+.teleprompter .step-timeline__pill:hover,
+.teleprompter .step-timeline__pill:focus-visible {
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border-color: color-mix(in srgb, var(--color-node-focus-stroke) 34%, var(--color-border));
+  color: var(--color-text);
+  outline: none;
+}
+
+.teleprompter__reader {
+  align-items: center;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 2.5rem minmax(0, 1fr) 2.5rem;
+  min-height: 0;
+  width: 100%;
 }
 
 .teleprompter__textarea {
-  flex: 1;
+  align-content: center;
+  display: grid;
+  max-height: 100%;
+  min-width: 0;
+  overflow-y: auto;
+  padding-inline: 0.35rem;
+  scrollbar-gutter: stable;
   text-align: center;
 }
 
@@ -474,5 +550,10 @@
     padding:
       clamp(8rem, 16vh, 11rem)
       max(5rem, 10vw);
+  }
+
+  .teleprompter {
+    left: 0.75rem;
+    right: 0.75rem;
   }
 }

--- a/packages/web-player/test/mermaid-diagram.test.ts
+++ b/packages/web-player/test/mermaid-diagram.test.ts
@@ -46,6 +46,23 @@ describe("mermaid diagram helpers", () => {
     );
   });
 
+  it("adds app-owned node classes for newly addressable flowchart IDs", () => {
+    const source = createRenderableDiagramSource({
+      elements: [
+        { id: "decision", kind: "node", label: "Decision" },
+        { id: "archive", kind: "node", label: "archive" },
+        { id: "metadata", kind: "node", label: "Metadata Node" }
+      ],
+      path: "./flowchart-addressability.mmd",
+      source: "flowchart LR\n  decision{Decision} --> archive\n  metadata@{ shape: rect, label: Metadata Node }",
+      type: "flowchart"
+    });
+
+    expect(source).toContain("class decision diagram_tour_node_decision;");
+    expect(source).toContain("class archive diagram_tour_node_archive;");
+    expect(source).toContain("class metadata diagram_tour_node_metadata;");
+  });
+
   it("keeps sequence-diagram source unchanged", () => {
     const source = createRenderableDiagramSource({
       elements: [

--- a/packages/web-player/test/tour-player.svelte.test.ts
+++ b/packages/web-player/test/tour-player.svelte.test.ts
@@ -234,7 +234,7 @@ describe("tour-player.svelte", () => {
     expect(screen.queryByTestId("minimap-shell")).toBeNull();
   });
 
-  it("restores the persisted collapsed minimap state and can be reopened", async () => {
+  it("restores the persisted hidden minimap state and can be reopened from the dock", async () => {
     window.localStorage.setItem("diagram-tour:minimap-collapsed", "true");
 
     render(TourPlayer, {
@@ -243,22 +243,112 @@ describe("tour-player.svelte", () => {
       tour: resolvedPaymentFlowTour,
     });
 
-    expect(await screen.findByTestId("minimap-shell")).toBeDefined();
-    expect(screen.queryByTestId("minimap-surface")).toBeNull();
-    expect(
-      screen.getByTestId("minimap-toggle").getAttribute("aria-expanded"),
-    ).toBe("false");
+    await screen.findByTestId("step-text");
+    expect(screen.queryByTestId("camera-control-panel")).toBeNull();
+    expect(screen.getByTestId("floating-panel-dock")).toBeDefined();
+    expect(screen.getByTestId("restore-minimap-button")).toBeDefined();
 
-    await fireEvent.click(screen.getByTestId("minimap-toggle"));
+    await fireEvent.click(screen.getByTestId("restore-minimap-button"));
 
-    expect(
-      screen.getByTestId("minimap-toggle").getAttribute("aria-expanded"),
-    ).toBe("true");
     await waitFor(() => {
+      expect(screen.getByTestId("camera-control-panel")).toBeDefined();
       expect(screen.getByTestId("minimap-surface")).toBeDefined();
     });
     expect(window.localStorage.getItem("diagram-tour:minimap-collapsed")).toBe(
       "false",
+    );
+  });
+
+  it("restores the persisted hidden teleprompter state and can be reopened from the dock", async () => {
+    window.localStorage.setItem("diagram-tour:teleprompter-hidden", "true");
+
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour,
+    });
+
+    await screen.findByTestId("camera-control-panel");
+    expect(screen.queryByTestId("teleprompter")).toBeNull();
+    expect(screen.getByTestId("floating-panel-dock")).toBeDefined();
+    expect(screen.getByTestId("restore-teleprompter-button")).toBeDefined();
+
+    await fireEvent.click(screen.getByTestId("restore-teleprompter-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teleprompter")).toBeDefined();
+    });
+    expect(window.localStorage.getItem("diagram-tour:teleprompter-hidden")).toBe(
+      "false",
+    );
+  });
+
+  it("hides the minimap panel and lets the teleprompter take that space", async () => {
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour,
+    });
+
+    const teleprompter = await screen.findByTestId("teleprompter");
+    const initialStyle = teleprompter.getAttribute("style") ?? "";
+
+    expect(screen.getByTestId("camera-control-panel")).toBeDefined();
+    expect(initialStyle).toContain("15.5rem");
+
+    await fireEvent.click(screen.getByTestId("minimap-toggle"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("camera-control-panel")).toBeNull();
+      expect(screen.getByTestId("restore-minimap-button")).toBeDefined();
+      expect(screen.getByTestId("teleprompter").getAttribute("style")).toContain("right: 24px");
+      expect(screen.getByTestId("floating-panel-dock").getAttribute("style")).toContain(
+        "var(--floating-panel-height)",
+      );
+    });
+  });
+
+  it("can hide and restore the teleprompter from the dock", async () => {
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour,
+    });
+
+    expect(await screen.findByTestId("teleprompter")).toBeDefined();
+
+    await fireEvent.click(screen.getByTestId("teleprompter-toggle"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("teleprompter")).toBeNull();
+      expect(screen.getByTestId("restore-teleprompter-button")).toBeDefined();
+    });
+
+    expect(window.localStorage.getItem("diagram-tour:teleprompter-hidden")).toBe(
+      "true",
+    );
+
+    await fireEvent.click(screen.getByTestId("restore-teleprompter-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teleprompter")).toBeDefined();
+    });
+    expect(window.localStorage.getItem("diagram-tour:teleprompter-hidden")).toBe(
+      "false",
+    );
+  });
+
+  it("uses underscore minimize affordances for both panels", async () => {
+    render(TourPlayer, {
+      initialStepIndex: 0,
+      selectedSlug: "payment-flow",
+      tour: resolvedPaymentFlowTour,
+    });
+
+    expect(await screen.findByTestId("teleprompter-toggle")).toBeDefined();
+    expect(screen.getByTestId("minimap-toggle").textContent?.trim()).toContain("_");
+    expect(screen.getByTestId("teleprompter-toggle").getAttribute("title")).toBe(
+      "Hide teleprompter",
     );
   });
 


### PR DESCRIPTION
## Summary
- expand flowchart node addressability so tours can target additional Mermaid flowchart shapes
- update the player teleprompter/minimap floating panels with persisted hide state, shared minimize affordances, and stronger CTA styling
- align smoke coverage with the current minimap collapse and fit-to-view behavior

## Testing
- bun run --cwd packages/web-player lint
- bun run --cwd packages/web-player typecheck
- bunx vitest run --config vitest.config.ts test/tour-player.svelte.test.ts
- bunx playwright test --config packages/web-player/playwright.config.ts packages/web-player/smoke/checkout-payment.collapsed-minimap.spec.ts
- bunx playwright test --config packages/web-player/playwright.config.ts packages/web-player/smoke/checkout-payment.zoom-controls.spec.ts