### PR TITLE
Add flowchart addressability example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ The public example library is intentionally minimal and canonical.
 Visible public set:
 
 - `checkout-payment-flow.*` for a small authored flowchart
+- `flowchart-addressability.*` for a flowchart example with common shapes, bare endpoints, and a tooltip annotation
 - `sequence-order-sequence.*` for a small authored sequence diagram
 - `payments-platform-overview.*` for a large authored interactive demo
 

--- a/examples/flowchart-addressability.mmd
+++ b/examples/flowchart-addressability.mmd
@@ -1,0 +1,9 @@
+flowchart LR
+  intake[Inbound Intake] --> decision{Decision}
+  decision -- Approved --> archive
+  decision -- Review --> manual_review[/Manual Review\]
+  manual_review --> queue[(Review Queue)]
+  queue --> worker((Worker))
+  worker --> done@{ shape: rect, label: "Done" }
+
+  click decision "https://example.com/decision" "Decision rule details"

--- a/examples/flowchart-addressability.tour.yaml
+++ b/examples/flowchart-addressability.tour.yaml
@@ -1,0 +1,25 @@
+version: 1
+title: Flowchart Addressability
+diagram: ./flowchart-addressability.mmd
+
+steps:
+  - focus:
+      - intake
+      - decision
+    text: >
+      {{intake}} feeds the branching {{decision}} that controls the rest of the flow.
+
+  - focus:
+      - archive
+      - manual_review
+      - queue
+      - worker
+      - done
+    text: >
+      This path shows common flowchart shapes, including bare endpoints like {{archive}}
+      and metadata-shaped nodes like {{done}}.
+
+  - focus: []
+    text: >
+      The flowchart stays fully navigable in the browser while the diagram source keeps
+      its original Mermaid annotations.

--- a/packages/parser/test/diagram-model.test.ts
+++ b/packages/parser/test/diagram-model.test.ts
@@ -62,6 +62,32 @@ describe("@diagram-tour/parser diagram model", () => {
     expect(model.renderSource).toContain("metadata@{ shape: rect, label: Metadata Node }");
   });
 
+  it("extracts flowchart nodes from a full addressability sample with clickable annotations", () => {
+    const model = createDiagramModel(
+      [
+        "flowchart LR",
+        "  intake[Inbound Intake] --> decision{Decision}",
+        "  decision -- Approved --> archive",
+        "  decision -- Review --> manual_review[/Manual Review\\]",
+        "  manual_review --> queue[(Review Queue)]",
+        "  queue --> worker((Worker))",
+        '  worker --> done@{ shape: rect, label: "Done" }',
+        '  click decision "https://example.com/decision" "Decision rule details"'
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "intake", kind: "node", label: "Inbound Intake" },
+      { id: "decision", kind: "node", label: "Decision" },
+      { id: "archive", kind: "node", label: "archive" },
+      { id: "manual_review", kind: "node", label: "Manual Review" },
+      { id: "queue", kind: "node", label: "Review Queue" },
+      { id: "worker", kind: "node", label: "Worker" },
+      { id: "done", kind: "node", label: "Done" }
+    ]);
+  });
+
   it("extracts bare flowchart link endpoints with id fallback labels", () => {
     const model = createDiagramModel(
       ["flowchart LR", "  source --> target", "  target -- Approved --> archive"].join("\n"),

--- a/packages/parser/test/tour-collection.test.ts
+++ b/packages/parser/test/tour-collection.test.ts
@@ -81,6 +81,24 @@ describe("@diagram-tour/parser tour collection", () => {
     expect(entry.tour.diagram.source).not.toContain("[request_sent]");
   });
 
+  it("builds a one-tour collection from the flowchart addressability example", async () => {
+    const collection = await loadResolvedTourCollection(
+      resolve(EXAMPLES_ROOT, "./flowchart-addressability.tour.yaml")
+    );
+
+    expect(collection.entries).toHaveLength(1);
+    expect(collection.entries[0]).toMatchObject({
+      slug: "flowchart-addressability",
+      sourcePath: "flowchart-addressability.tour.yaml",
+      title: "Flowchart Addressability"
+    });
+    expect(collection.entries[0]?.tour.steps.map((step) => step.text)).toEqual([
+      "Inbound Intake feeds the branching Decision that controls the rest of the flow.\n",
+      "This path shows common flowchart shapes, including bare endpoints like archive and metadata-shaped nodes like Done.\n",
+      "The flowchart stays fully navigable in the browser while the diagram source keeps its original Mermaid annotations.\n"
+    ]);
+  });
+
   it("discovers matching .tour.yaml files from a directory target", async () => {
     const collection = await loadResolvedTourCollection(DISCOVERY_FIXTURE_ROOT);
 
@@ -322,6 +340,7 @@ describe("@diagram-tour/parser tour collection", () => {
 
     expect(collection.entries.map((entry) => entry.slug)).toEqual([
       "checkout-payment-flow",
+      "flowchart-addressability",
       "payments-platform-overview",
       "sequence-order-sequence",
     ]);

--- a/packages/web-player/smoke/flowchart-addressability.authored-end-to-end.spec.ts
+++ b/packages/web-player/smoke/flowchart-addressability.authored-end-to-end.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+import { expectDiagramVisible, expectFocusedNodeToStayAwayFromCanvasOrigin } from "./smoke-test-helpers";
+import { startDevServer } from "./dev-server";
+
+test("authored flowchart addressability stays usable end to end", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("diagram-tour-theme", "dark");
+  });
+
+  const server = await startDevServer({
+    args: ["./examples/flowchart-addressability.tour.yaml"],
+    port: 4195
+  });
+
+  try {
+    await page.goto(server.baseUrl);
+    await expectDiagramVisible(page);
+    await expect(page.getByTestId("step-text-container")).toContainText("Inbound Intake feeds");
+    await expect(page.locator('[data-testid="diagram-container"] [data-node-id="decision"]')).toHaveAttribute(
+      "data-step-target",
+      "true"
+    );
+
+    await expectFocusedNodeToStayAwayFromCanvasOrigin(page, "decision");
+    await page.getByTestId("next-button").click();
+
+    await expect(page).toHaveURL(/\/flowchart-addressability\?step=2$/);
+    await expect(page.getByTestId("step-text-container")).toContainText("bare endpoints like archive");
+    await expectFocusedNodeToStayAwayFromCanvasOrigin(page, "archive");
+    await expect(page.getByTestId("theme-root")).toHaveAttribute("data-theme", "dark");
+
+    await page.getByTestId("theme-toggle").click();
+    await expect(page.getByTestId("theme-root")).toHaveAttribute("data-theme", "light");
+    await expect(page.getByTestId("step-text-container")).toBeVisible();
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/web-player/test/layout.server.test.ts
+++ b/packages/web-player/test/layout.server.test.ts
@@ -27,6 +27,7 @@ describe("+layout.server", () => {
 
     expect(result.collection.entries.map((entry) => entry.slug)).toEqual([
       "checkout-payment-flow",
+      "flowchart-addressability",
       "payments-platform-overview",
       "sequence-order-sequence"
     ]);
@@ -43,8 +44,9 @@ describe("+layout.server", () => {
 
     expect(result.collection.entries.map((entry) => entry.title)).toEqual([
       "Payment Flow",
+      "Flowchart Addressability",
       "Payments Platform Overview",
-      "Order Sequence",
+      "Order Sequence"
     ]);
     expect(result.collection.skipped).toEqual([]);
     expect(result.sourceTarget.kind).toBe("directory");

--- a/packages/web-player/test/mermaid-diagram.test.ts
+++ b/packages/web-player/test/mermaid-diagram.test.ts
@@ -63,6 +63,23 @@ describe("mermaid diagram helpers", () => {
     expect(source).toContain("class metadata diagram_tour_node_metadata;");
   });
 
+  it("keeps flowchart click annotations in the rendered Mermaid source", () => {
+    const source = createRenderableDiagramSource({
+      elements: [{ id: "decision", kind: "node", label: "Decision" }],
+      path: "./flowchart-addressability.mmd",
+      source: [
+        "flowchart LR",
+        "  decision{Decision}",
+        '  click decision "https://example.com/decision" "Decision rule details"'
+      ].join("\n"),
+      type: "flowchart"
+    });
+
+    expect(source).toContain(
+      'click decision "https://example.com/decision" "Decision rule details"'
+    );
+  });
+
   it("keeps sequence-diagram source unchanged", () => {
     const source = createRenderableDiagramSource({
       elements: [


### PR DESCRIPTION
Adds a new flowchart addressability example, parser coverage, web-player smoke coverage, and layout expectations for the expanded examples set.