### PR TITLE
Add Mermaid Sankey support end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 It can load:
 
 - Mermaid diagram files such as `payment-flow.mmd` or `release-pipeline.mermaid`
-- Mermaid flowcharts and Mermaid sequence diagrams
+- Mermaid flowcharts, Mermaid sequence diagrams, and common Mermaid Sankey diagrams
 - Markdown files with fenced `mermaid` blocks, including AI-generated docs
 - optional matching `*.tour.yaml` files
 - version 1 tour content with `version`, `title`, `diagram`, and `steps` when you want authored enrichment
@@ -130,7 +130,9 @@ Raw diagrams work immediately. If a diagram has no authored tour yet, `diagram-t
 - an overview step for the whole diagram
 - one step per addressable Mermaid diagram element in source order
 
-For flowcharts, that means one step per Mermaid node. For sequence diagrams, that means one step per explicit participant plus one step per explicitly tagged message.
+For flowcharts, that means one step per Mermaid node. For sequence diagrams, that means one step per explicit participant plus one step per explicitly tagged message. For Sankey diagrams, that means one step per Sankey node in source order.
+
+Sankey diagrams use `sankey-beta` with CSV-like rows. In authored tours, Sankey `focus` values and `{{text references}}` use raw visible node labels such as `Gateway` or `Fraud Review`. If the same visible label appears more than once, the first source-order match wins.
 
 Add a `*.tour.yaml` file only when you want richer titles, custom step text, curated focus groups, and label interpolation.
 
@@ -230,7 +232,7 @@ Other available commands:
 - `bun run smoke`
 - `bun run prepush`
 
-The shipped example library lives directly under `examples/` as a minimal canonical set with `checkout-payment-flow`, `sequence-order-sequence`, and `payments-platform-overview`.
+The shipped example library lives directly under `examples/` as a minimal canonical set with `checkout-payment-flow`, `sequence-order-sequence`, `payments-platform-overview`, and `sankey-ops-review` for an interview-to-offer Sankey walkthrough.
 
 ## Repository Packages
 

--- a/docs/authoring-guide.md
+++ b/docs/authoring-guide.md
@@ -8,7 +8,7 @@ It also supports Markdown files that contain fenced ```mermaid blocks. This is e
 
 ## Start with Stable Mermaid IDs
 
-Every diagram element that may appear in `focus` or `{{references}}` needs a stable, addressable Mermaid ID.
+Every diagram element that may appear in `focus` or `{{references}}` needs a stable, addressable Mermaid reference.
 
 Use readable, stable IDs:
 
@@ -141,7 +141,7 @@ examples/
 
 The runtime will generate an overview step plus one step per addressable Mermaid diagram element until you add an authored tour file.
 
-For flowcharts, that is one step per node. For sequence diagrams, that is one step per explicit participant plus one step per explicitly tagged message.
+For flowcharts, that is one step per node. For sequence diagrams, that is one step per explicit participant plus one step per explicitly tagged message. For Sankey diagrams, that is one step per node in source order.
 
 Markdown-backed diagrams are also valid:
 
@@ -273,5 +273,25 @@ bun run dev
 Use the repository examples as references:
 
 - `checkout-payment-flow` for a small authored flowchart
+- `sankey-ops-review` for a small authored Sankey
 - `sequence-order-sequence` for an authored Mermaid sequence diagram
 - `payments-platform-overview` for a large authored demo that stresses minimap, zoom, and pan
+For Sankey diagrams, use common Mermaid `sankey-beta` CSV rows. Authored references use raw visible node labels, not generated IDs:
+
+```mermaid
+sankey-beta
+Checkout,Gateway,120
+Gateway,Fraud Review,20
+Gateway,Settlement,100
+```
+
+```yaml
+steps:
+  - focus:
+      - Gateway
+      - Fraud Review
+    text: >
+      {{Gateway}} may send traffic through {{Fraud Review}}.
+```
+
+If a visible Sankey label appears more than once, the first source-order match wins.

--- a/docs/interview-offers-pipeline.md
+++ b/docs/interview-offers-pipeline.md
@@ -1,0 +1,27 @@
+# Interview Offers Pipeline
+
+```mermaid
+sankey-beta
+Applications,Resume Review,180
+Resume Review,Recruiter Screen,120
+Resume Review,Rejected Early,60
+Recruiter Screen,Hiring Manager,90
+Recruiter Screen,Rejected After Screen,30
+Hiring Manager,Take-home,35
+Hiring Manager,Live Coding,20
+Hiring Manager,Panel,25
+Hiring Manager,Rejected By Team,10
+Take-home,Final Loop,22
+Live Coding,Final Loop,12
+Panel,Final Loop,18
+Take-home,Rejected After Exercise,13
+Live Coding,Rejected After Exercise,8
+Panel,Rejected After Panel,7
+Final Loop,Reference Check,40
+Final Loop,Rejected Final,12
+Reference Check,Offers,34
+Reference Check,Offer Withdrawn,6
+Offers,Accepted,18
+Offers,Declined,10
+Offers,Negotiating,6
+```

--- a/docs/tour-spec-v1.md
+++ b/docs/tour-spec-v1.md
@@ -83,7 +83,7 @@ If a Markdown file contains multiple Mermaid blocks, the path must include a fra
 diagram: ./country-checklist.md#details
 ```
 
-The referenced diagram must contain addressable Mermaid element IDs.
+The referenced diagram must contain addressable Mermaid references.
 
 For flowcharts, that means node IDs that start with a letter and then use only letters, digits, or underscores:
 
@@ -263,7 +263,7 @@ When a workspace contains invalid authored tours, the player may still load vali
 
 ## Mermaid Requirements
 
-Version 1 supports Mermaid flowcharts and Mermaid sequence diagrams.
+Version 1 supports Mermaid flowcharts, Mermaid sequence diagrams, and common Mermaid Sankey diagrams.
 
 Flowchart node IDs must match `[A-Za-z][A-Za-z0-9_]*`.
 
@@ -338,6 +338,7 @@ Supported:
 
 - Mermaid flowcharts
 - Mermaid sequence diagrams with addressable participants and tagged messages
+- Common Mermaid Sankey diagrams with addressable node labels
 - YAML tour files
 - sequential tours
 - element highlighting or other player-defined focus rendering
@@ -353,6 +354,7 @@ Not supported:
 - player-specific viewport instructions in the tour file
 - Mermaid notes, activation bars, loops, alt blocks, and other non-addressable sequence constructs
 - flowchart edges, edge labels, tooltips, styles, classes, and subgraph boxes as addressable elements
+- Stable authored Sankey link references
 
 ## Future Directions
 
@@ -370,3 +372,17 @@ These are intentionally excluded from version 1.
 ## Philosophy
 
 Version 1 aims to feel like writing an explanation, not configuring a UI runtime.
+Sankey diagrams support addressable nodes by raw visible label:
+
+```mermaid
+sankey-beta
+Checkout,Gateway,120
+Gateway,Fraud Review,20
+Gateway,Settlement,100
+```
+
+- `Gateway`
+- `Fraud Review`
+- `Settlement`
+
+If the same visible Sankey label appears more than once, the first source-order match wins.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Visible public set:
 
 - `checkout-payment-flow.*` for a small authored flowchart
 - `flowchart-addressability.*` for a flowchart example with common shapes, bare endpoints, and a tooltip annotation
+- `sankey-ops-review.*` for an authored Sankey that follows a candidate interview pipeline through offers
 - `sequence-order-sequence.*` for a small authored sequence diagram
 - `payments-platform-overview.*` for a large authored interactive demo
 

--- a/examples/sankey-ops-review.mmd
+++ b/examples/sankey-ops-review.mmd
@@ -1,0 +1,23 @@
+sankey-beta
+Applications,Resume Review,180
+Resume Review,Recruiter Screen,120
+Resume Review,Rejected Early,60
+Recruiter Screen,Hiring Manager,90
+Recruiter Screen,Rejected After Screen,30
+Hiring Manager,Take-home,35
+Hiring Manager,Live Coding,20
+Hiring Manager,Panel,25
+Hiring Manager,Rejected By Team,10
+Take-home,Final Loop,22
+Live Coding,Final Loop,12
+Panel,Final Loop,18
+Take-home,Rejected After Exercise,13
+Live Coding,Rejected After Exercise,8
+Panel,Rejected After Panel,7
+Final Loop,Reference Check,40
+Final Loop,Rejected Final,12
+Reference Check,Offers,34
+Reference Check,Offer Withdrawn,6
+Offers,Accepted,18
+Offers,Declined,10
+Offers,Negotiating,6

--- a/examples/sankey-ops-review.tour.yaml
+++ b/examples/sankey-ops-review.tour.yaml
@@ -1,0 +1,37 @@
+version: 1
+title: Interview Offers Pipeline
+diagram: ./sankey-ops-review.mmd
+
+steps:
+  - focus: []
+    text: >
+      Overview of how one candidate funnel starts with many job applications, narrows through screening and interviews, and ends in real offer outcomes.
+
+  - focus:
+      - Applications
+      - Resume Review
+      - Recruiter Screen
+    text: >
+      {{Applications}} start broad, then {{Resume Review}} and {{Recruiter Screen}} remove obvious mismatches before the hiring team spends deeper interview time.
+
+  - focus:
+      - Hiring Manager
+      - Take-home
+      - Live Coding
+      - Panel
+    text: >
+      {{Hiring Manager}} splits promising candidates into different interview formats such as {{Take-home}}, {{Live Coding}}, and {{Panel}} depending on role and team preference.
+
+  - focus:
+      - Final Loop
+      - Reference Check
+    text: >
+      Candidates who survive the working interview stages converge into {{Final Loop}}, then move through {{Reference Check}} before an offer can be prepared.
+
+  - focus:
+      - Offers
+      - Accepted
+      - Declined
+      - Negotiating
+    text: >
+      {{Offers}} branch into accepted, declined, and still-{{Negotiating}} outcomes, which makes the funnel useful for both recruiting ops and forecasting.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export interface DiagramTour {
   steps: TourStep[];
 }
 
-export type DiagramType = "flowchart" | "sequence";
+export type DiagramType = "flowchart" | "sequence" | "sankey";
 
 export type DiagramElementKind = "node" | "participant" | "message";
 

--- a/packages/parser/src/diagram-model.ts
+++ b/packages/parser/src/diagram-model.ts
@@ -8,6 +8,7 @@ import type {
 
 import type { DiagramModel } from "./parser-contracts.js";
 import { createFlowchartDiagramModel } from "./flowchart-diagram-model.js";
+import { createSankeyDiagramModel } from "./sankey-diagram-model.js";
 import { createSequenceDiagramModel } from "./sequence-diagram-model.js";
 import {
   createStepFieldMessage,
@@ -16,17 +17,20 @@ import {
   type TourContext
 } from "./tour-context.js";
 
-const NODE_REFERENCE_PATTERN = /{{\s*([A-Za-z][A-Za-z0-9_]*)\s*}}/g;
+const NODE_REFERENCE_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
 const SEQUENCE_DIAGRAM_PATTERN = /^\s*sequenceDiagram\b/mu;
+const SANKEY_DIAGRAM_PATTERN = /^\s*sankey-beta\b/mu;
 
 type ElementIndex = Map<string, DiagramElement>;
 
 export function createDiagramModel(source: string, context: TourContext): DiagramModel {
   const type = detectDiagramType(source);
 
-  return type === "sequence"
-    ? createSequenceDiagramModel(source, context)
-    : createFlowchartDiagramModel(source);
+  if (type === "sequence") {
+    return createSequenceDiagramModel(source, context);
+  }
+
+  return type === "sankey" ? createSankeyDiagramModel(source) : createFlowchartDiagramModel(source);
 }
 
 export function resolveLoadedTour(input: {
@@ -36,7 +40,7 @@ export function resolveLoadedTour(input: {
   rawTour: DiagramTour;
 }): ResolvedDiagramTour {
   const diagramModel = createDiagramModel(input.diagramSource, input.context);
-  const elementIndex = createElementIndex(diagramModel.elements);
+  const elementIndex = createElementIndex(diagramModel.elements, diagramModel.type);
 
   return {
     sourceKind: "authored",
@@ -81,8 +85,23 @@ export function createResolvedDiagram(
   };
 }
 
-export function createElementIndex(elements: DiagramElement[]): Map<string, DiagramElement> {
-  return new Map(elements.map((element) => [element.id, element]));
+export function createElementIndex(
+  elements: DiagramElement[],
+  diagramType: DiagramType
+): Map<string, DiagramElement> {
+  const index = new Map(elements.map((element) => [element.id, element]));
+
+  if (diagramType !== "sankey") {
+    return index;
+  }
+
+  elements.forEach((element) => {
+    if (!index.has(element.label)) {
+      index.set(element.label, element);
+    }
+  });
+
+  return index;
 }
 
 export function createUnknownElementMessage(input: {
@@ -104,7 +123,11 @@ export function readTextReferenceIds(text: string): string[] {
 }
 
 function detectDiagramType(source: string): DiagramType {
-  return SEQUENCE_DIAGRAM_PATTERN.test(source) ? "sequence" : "flowchart";
+  if (SEQUENCE_DIAGRAM_PATTERN.test(source)) {
+    return "sequence";
+  }
+
+  return SANKEY_DIAGRAM_PATTERN.test(source) ? "sankey" : "flowchart";
 }
 
 function resolveLoadedTourSteps(
@@ -197,5 +220,9 @@ function resolveElement(input: {
 }
 
 function readUnknownElementTarget(diagramType: DiagramType): string {
-  return diagramType === "sequence" ? "participant or message id" : "node id";
+  if (diagramType === "sequence") {
+    return "participant or message id";
+  }
+
+  return diagramType === "sankey" ? "node label" : "node id";
 }

--- a/packages/parser/src/resolved-draft-diagnostics.ts
+++ b/packages/parser/src/resolved-draft-diagnostics.ts
@@ -17,7 +17,7 @@ export function validateResolvedTourDraft(input: {
   source: string;
 }): TourDiagnostic[] {
   const collector = createTourValidationCollector();
-  const elementIndex = createElementIndex(input.diagramModel.elements);
+  const elementIndex = createElementIndex(input.diagramModel.elements, input.diagramModel.type);
   const lineCounter = createSourceLineCounter(input.source);
 
   input.draft.steps.forEach((step, index) =>

--- a/packages/parser/src/sankey-diagram-model.ts
+++ b/packages/parser/src/sankey-diagram-model.ts
@@ -1,0 +1,108 @@
+import type { DiagramElement } from "@diagram-tour/core";
+
+import type { DiagramModel } from "./parser-contracts.js";
+
+const SANKEY_ROW_PATTERN =
+  /^\s*(?:"((?:[^"]|"")*)"|([^,"]*))\s*,\s*(?:"((?:[^"]|"")*)"|([^,"]*))\s*,\s*(?:"((?:[^"]|"")*)"|([^,"]*))\s*$/u;
+
+type SankeyElementDraft = {
+  label: string;
+};
+
+export function createSankeyDiagramModel(source: string): DiagramModel {
+  return {
+    elements: extractSankeyElements(source),
+    renderSource: source,
+    type: "sankey"
+  };
+}
+
+function extractSankeyElements(source: string): DiagramElement[] {
+  const elements: DiagramElement[] = [];
+  const seen = new Set<string>();
+
+  for (const line of source.split("\n").slice(1)) {
+    readSankeyLineElements(line).forEach((draft) => {
+      registerSankeyElement(elements, seen, draft);
+    });
+  }
+
+  return elements;
+}
+
+function readSankeyLineElements(line: string): SankeyElementDraft[] {
+  if (shouldIgnoreSankeyLine(line)) {
+    return [];
+  }
+
+  const cells = parseSankeyCsvLine(line);
+
+  return cells === null ? [] : createSankeyLineElements(cells);
+}
+
+function shouldIgnoreSankeyLine(line: string): boolean {
+  const trimmed = line.trim();
+
+  return trimmed.length === 0 || trimmed.startsWith("%%");
+}
+
+function createSankeyLineElements(cells: string[]): SankeyElementDraft[] {
+  if (!hasValidSankeyCells(cells)) {
+    return [];
+  }
+
+  return [createSankeyElementDraft(cells[0]!), createSankeyElementDraft(cells[1]!)];
+}
+
+function hasValidSankeyCells(cells: string[]): boolean {
+  return hasSankeyNodePair(cells) && hasSankeyValue(cells[2]);
+}
+
+function parseSankeyCsvLine(line: string): string[] | null {
+  const match = line.match(SANKEY_ROW_PATTERN);
+
+  return match === null ? null : [readSankeyCell(match, 1, 2), readSankeyCell(match, 3, 4), readSankeyCell(match, 5, 6)];
+}
+
+function createSankeyElementDraft(label: string): SankeyElementDraft {
+  return { label };
+}
+
+function hasSankeyNodeLabel(value: string | undefined): boolean {
+  return value !== undefined && value.length > 0;
+}
+
+function hasSankeyValue(value: string | undefined): boolean {
+  return value !== undefined && Number.isFinite(Number(value));
+}
+
+function hasSankeyNodePair(cells: string[]): boolean {
+  return hasSankeyNodeLabel(cells[0]) && hasSankeyNodeLabel(cells[1]);
+}
+
+function readSankeyCell(match: RegExpMatchArray, quotedIndex: number, bareIndex: number): string {
+  const quoted = match.at(quotedIndex);
+
+  if (quoted !== undefined) {
+    return quoted.replaceAll('""', '"').trim();
+  }
+
+  return match.at(bareIndex)!.trim();
+}
+
+function registerSankeyElement(
+  elements: DiagramElement[],
+  seen: Set<string>,
+  draft: SankeyElementDraft
+): void {
+  if (seen.has(draft.label)) {
+    return;
+  }
+
+  seen.add(draft.label);
+  elements.push({
+    id: draft.label,
+    kind: "node",
+    label: draft.label
+  });
+}

--- a/packages/parser/test/diagram-model.test.ts
+++ b/packages/parser/test/diagram-model.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createDiagramModel, createGeneratedSteps, resolveLoadedTour } from "../src/diagram-model.js";
+import {
+  createDiagramModel,
+  createElementIndex,
+  createGeneratedSteps,
+  resolveLoadedTour
+} from "../src/diagram-model.js";
 import { createTourContext } from "../src/tour-context.js";
 import { restoreParserTestState } from "./parser-test-support.js";
 
@@ -189,6 +194,85 @@ describe("@diagram-tour/parser diagram model", () => {
     expect(model.renderSource).not.toContain("[request_sent]");
   });
 
+  it("detects sankey diagrams and extracts unique nodes in first-seen source order", () => {
+    const model = createDiagramModel(
+      [
+        "sankey-beta",
+        "Checkout,Gateway,120",
+        "Gateway,Fraud Review,20",
+        "Gateway,Settlement,100",
+        "Fraud Review,Settlement,15",
+        "Settlement,Bank,115"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model).toMatchObject({
+      type: "sankey",
+      elements: [
+        { id: "Checkout", kind: "node", label: "Checkout" },
+        { id: "Gateway", kind: "node", label: "Gateway" },
+        { id: "Fraud Review", kind: "node", label: "Fraud Review" },
+        { id: "Settlement", kind: "node", label: "Settlement" },
+        { id: "Bank", kind: "node", label: "Bank" }
+      ]
+    });
+  });
+
+  it("parses common sankey csv details including decimals, quotes, commas, comments, and blank lines", () => {
+    const model = createDiagramModel(
+      [
+        "sankey-beta",
+        "%% source,target,value",
+        "\"North, America\",Gateway,120.5",
+        "",
+        "Gateway,\"Quoted \"\"Review\"\"\",20.25",
+        "Gateway,Settlement,100"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "North, America", kind: "node", label: "North, America" },
+      { id: "Gateway", kind: "node", label: "Gateway" },
+      { id: 'Quoted "Review"', kind: "node", label: 'Quoted "Review"' },
+      { id: "Settlement", kind: "node", label: "Settlement" }
+    ]);
+  });
+
+  it("ignores malformed or non-standard sankey rows that do not produce a valid common-case triple", () => {
+    const model = createDiagramModel(
+      [
+        "sankey-beta",
+        "Checkout,Gateway,not-a-number",
+        "\"Unclosed,Gateway,20",
+        "Too,Many,Columns,10",
+        ",Gateway,20",
+        "Checkout,Gateway,120"
+      ].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(model.elements).toEqual([
+      { id: "Checkout", kind: "node", label: "Checkout" },
+      { id: "Gateway", kind: "node", label: "Gateway" }
+    ]);
+  });
+
+  it("creates sankey generated steps as overview plus one step per unique node", () => {
+    const model = createDiagramModel(
+      ["sankey-beta", "Gateway,Settlement,100", "Gateway,Bank,20"].join("\n"),
+      createTourContext("/tmp/diagram.mmd")
+    );
+
+    expect(createGeneratedSteps(model.elements, "Sankey Example").map((step) => step.text)).toEqual([
+      "Overview of Sankey Example.",
+      "Focus on Gateway.",
+      "Focus on Settlement.",
+      "Focus on Bank."
+    ]);
+  });
+
   it("fails on duplicate sequence ids", () => {
     expect(() =>
       createDiagramModel(
@@ -225,5 +309,40 @@ describe("@diagram-tour/parser diagram model", () => {
         text: "Focus on API Gateway."
       }
     ]);
+  });
+
+  it("resolves sankey authored references by visible label and picks first duplicate match", () => {
+    const resolved = resolveLoadedTour({
+      context: createTourContext("/tmp/tour.tour.yaml"),
+      diagramPath: "./diagram.mmd",
+      diagramSource: ["sankey-beta", "Gateway,Settlement,100", "Gateway,Bank,20"].join("\n"),
+      rawTour: {
+        version: 1,
+        title: "Valid Tour",
+        diagram: "./diagram.mmd",
+        steps: [
+          {
+            focus: ["Gateway"],
+            text: "Focus on {{Gateway}}."
+          }
+        ]
+      }
+    });
+
+    expect(resolved.steps).toEqual([
+      {
+        focus: [{ id: "Gateway", kind: "node", label: "Gateway" }],
+        index: 1,
+        text: "Focus on Gateway."
+      }
+    ]);
+  });
+
+  it("indexes sankey labels when authored labels differ from internal ids", () => {
+    const element = { id: "gateway__internal", kind: "node" as const, label: "Gateway" };
+    const index = createElementIndex([element], "sankey");
+
+    expect(index.get("gateway__internal")).toEqual(element);
+    expect(index.get("Gateway")).toEqual(element);
   });
 });

--- a/packages/parser/test/load-resolved-tour.test.ts
+++ b/packages/parser/test/load-resolved-tour.test.ts
@@ -320,6 +320,123 @@ describe("@diagram-tour/parser loadResolvedTour", () => {
     });
   });
 
+  it("loads a valid sankey tour with visible-label references", async () => {
+    const tourPath = await createTempTour({
+      mermaid: [
+        "sankey-beta",
+        "Checkout,Gateway,120",
+        "Gateway,Fraud Review,20",
+        "Gateway,Settlement,100",
+        "Fraud Review,Settlement,15",
+        "Settlement,Bank,115"
+      ].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Sankey Tour",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Gateway",
+        "      - Fraud Review",
+        "    text: >",
+        "      {{Gateway}} can route work through {{Fraud Review}}."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      title: "Sankey Tour",
+      diagram: {
+        type: "sankey",
+        source: [
+          "sankey-beta",
+          "Checkout,Gateway,120",
+          "Gateway,Fraud Review,20",
+          "Gateway,Settlement,100",
+          "Fraud Review,Settlement,15",
+          "Settlement,Bank,115"
+        ].join("\n")
+      },
+      steps: [
+        {
+          focus: [
+            { id: "Gateway", kind: "node", label: "Gateway" },
+            { id: "Fraud Review", kind: "node", label: "Fraud Review" }
+          ],
+          text: "Gateway can route work through Fraud Review.\n"
+        }
+      ]
+    });
+  });
+
+  it("resolves duplicate sankey labels to first source-order match", async () => {
+    const tourPath = await createTempTour({
+      mermaid: ["sankey-beta", "Gateway,Settlement,100", "Gateway,Bank,20"].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Sankey Duplicates",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Gateway",
+        "    text: >",
+        "      {{Gateway}} is first."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      steps: [
+        {
+          focus: [{ id: "Gateway", kind: "node", label: "Gateway" }],
+          text: "Gateway is first.\n"
+        }
+      ]
+    });
+  });
+
+  it("fails when a sankey focus reference uses an unknown node label", async () => {
+    const tourPath = await createTempTour({
+      mermaid: ["sankey-beta", "Checkout,Gateway,120"].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Broken Sankey Tour",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Missing Label",
+        "    text: >",
+        "      Overview."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).rejects.toThrow(
+      `Tour "${normalizePath(tourPath)}": step 1 focus references unknown Mermaid node label "Missing Label"`
+    );
+  });
+
+  it("fails when a sankey text reference uses an unknown node label", async () => {
+    const tourPath = await createTempTour({
+      mermaid: ["sankey-beta", "Checkout,Gateway,120"].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Broken Sankey Tour",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Checkout",
+        "    text: >",
+        "      {{Missing Label}} is not valid."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).rejects.toThrow(
+      `Tour "${normalizePath(tourPath)}": step 1 text references unknown Mermaid node label "Missing Label"`
+    );
+  });
+
   it("uses the participant id as the label when a sequence participant has no alias", async () => {
     const tourPath = await createTempTour({
       mermaid: ["sequenceDiagram", "  participant api", "  api->>api: [self_check] Self check"].join(

--- a/packages/parser/test/markdown-discovery.test.ts
+++ b/packages/parser/test/markdown-discovery.test.ts
@@ -352,6 +352,51 @@ describe("@diagram-tour/parser markdown discovery", () => {
     });
   });
 
+  it("loads an authored tour that selects a markdown sankey block by fragment", async () => {
+    const tourPath = await createTempTour({
+      diagramPath: "diagram.md",
+      mermaid: [
+        "# Overview",
+        "",
+        "```mermaid",
+        "flowchart TD",
+        "  start[Start] --> finish[Finish]",
+        "```",
+        "",
+        "# Sankey",
+        "",
+        "```mermaid",
+        "sankey-beta",
+        "Checkout,Gateway,120",
+        "Gateway,Fraud Review,20",
+        "```"
+      ].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Markdown Sankey Tour",
+        "diagram: ./diagram.md#sankey",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Gateway",
+        "    text: >",
+        "      Focus on {{Gateway}}."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      diagram: {
+        path: "./diagram.md#sankey",
+        type: "sankey"
+      },
+      steps: [
+        {
+          text: "Focus on Gateway.\n"
+        }
+      ]
+    });
+  });
+
   it("fails when a markdown fragment does not exist", async () => {
     const tourPath = await createTempTour({
       diagramPath: "diagram.md",

--- a/packages/parser/test/tour-collection.test.ts
+++ b/packages/parser/test/tour-collection.test.ts
@@ -81,6 +81,40 @@ describe("@diagram-tour/parser tour collection", () => {
     expect(entry.tour.diagram.source).not.toContain("[request_sent]");
   });
 
+  it("builds generated fallback steps from a raw sankey diagram file target with unique nodes", async () => {
+    const sankeyRoot = await createTempDiagramDirectory({
+      "diagrams/ops-sankey.mmd": [
+        "sankey-beta",
+        "Checkout,Gateway,120",
+        "Gateway,Fraud Review,20",
+        "Gateway,Settlement,100",
+        "Fraud Review,Settlement,15",
+        "Settlement,Bank,115"
+      ].join("\n")
+    });
+
+    const collection = await loadResolvedTourCollection(resolve(sankeyRoot, "./diagrams/ops-sankey.mmd"));
+    const entry = readCollectionEntryAt(collection, 0);
+
+    expect(collection.entries).toHaveLength(1);
+    expect(entry.tour.diagram.type).toBe("sankey");
+    expect(entry.tour.diagram.elements.map((element) => element.id)).toEqual([
+      "Checkout",
+      "Gateway",
+      "Fraud Review",
+      "Settlement",
+      "Bank"
+    ]);
+    expect(entry.tour.steps.map((step) => step.text)).toEqual([
+      "Overview of Ops Sankey.",
+      "Focus on Checkout.",
+      "Focus on Gateway.",
+      "Focus on Fraud Review.",
+      "Focus on Settlement.",
+      "Focus on Bank."
+    ]);
+  });
+
   it("builds a one-tour collection from the flowchart addressability example", async () => {
     const collection = await loadResolvedTourCollection(
       resolve(EXAMPLES_ROOT, "./flowchart-addressability.tour.yaml")
@@ -342,6 +376,7 @@ describe("@diagram-tour/parser tour collection", () => {
       "checkout-payment-flow",
       "flowchart-addressability",
       "payments-platform-overview",
+      "sankey-ops-review",
       "sequence-order-sequence",
     ]);
   });

--- a/packages/web-player/smoke/sankey-ops-review.authored-end-to-end.spec.ts
+++ b/packages/web-player/smoke/sankey-ops-review.authored-end-to-end.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+import { expectDiagramVisible } from "./smoke-test-helpers";
+import { startDevServer } from "./dev-server";
+
+test("authored sankey tour stays usable end to end", async ({ page }) => {
+  const server = await startDevServer({
+    args: ["./examples/sankey-ops-review.tour.yaml"],
+    port: 4197
+  });
+
+  try {
+    await page.goto(server.baseUrl);
+    await expectDiagramVisible(page);
+    await expect(page.getByTestId("step-text-container")).toContainText("Overview of how one candidate funnel starts");
+    await expect(
+      page.locator('[data-testid="diagram-container"] .nodes .node[data-node-id="Applications"]')
+    ).not.toHaveAttribute("data-focus-state", "focused");
+
+    await page.getByTestId("next-button").click();
+
+    await expect(page).toHaveURL(/\/sankey-ops-review\?step=2$/);
+    await expect(page.getByTestId("step-text-container")).toContainText("Recruiter Screen");
+    await expect(
+      page.locator('[data-testid="diagram-container"] .nodes .node[data-node-id="Applications"]')
+    ).toHaveAttribute("data-focus-state", "focused");
+    await expect(
+      page.locator('[data-testid="diagram-container"] .nodes .node[data-node-id="Recruiter Screen"]')
+    ).toHaveAttribute("data-focus-state", "focused");
+
+    const themeRoot = page.getByTestId("theme-root");
+    const beforeToggle = await themeRoot.getAttribute("data-theme");
+
+    await page.getByTestId("theme-toggle").click();
+    await expect(themeRoot).toHaveAttribute("data-theme", beforeToggle === "dark" ? "light" : "dark");
+    await expect(page.getByTestId("step-text-container")).toBeVisible();
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/web-player/src/lib/mermaid-diagram.ts
+++ b/packages/web-player/src/lib/mermaid-diagram.ts
@@ -57,6 +57,7 @@ export async function renderMermaidDiagram(input: {
   const mermaid = await loadMermaid();
 
   mermaid.default.initialize({
+    ...readMermaidDiagramConfig(input.diagram),
     startOnLoad: false,
     theme: "base",
     themeVariables: readMermaidThemeVariables(input.container)
@@ -98,7 +99,7 @@ export function applyFocusState(input: {
 }
 
 export function createRenderableDiagramSource(diagram: ResolvedDiagram): string {
-  if (diagram.type === "sequence") {
+  if (diagram.type !== "flowchart") {
     return diagram.source;
   }
 
@@ -111,6 +112,20 @@ export function createRenderableDiagramSource(diagram: ResolvedDiagram): string 
 
 export function getMermaidErrorMessage(): string {
   return MERMAID_ERROR_MESSAGE;
+}
+
+function readMermaidDiagramConfig(diagram: ResolvedDiagram): Record<string, unknown> {
+  if (diagram.type !== "sankey") {
+    return {};
+  }
+
+  return {
+    sankey: {
+      height: 860,
+      useMaxWidth: false,
+      width: 1560
+    }
+  };
 }
 
 async function loadMermaid(): Promise<MermaidModule> {
@@ -205,6 +220,12 @@ function annotateRenderedElements(container: HTMLElement, diagram: ResolvedDiagr
     return;
   }
 
+  if (diagram.type === "sankey") {
+    annotateSankeyElements(container, diagram.elements);
+
+    return;
+  }
+
   annotateFlowchartElements(container, diagram.elements);
 }
 
@@ -218,6 +239,25 @@ function annotateFlowchartElements(container: HTMLElement, elements: DiagramElem
 
     setDiagramElementDataset(renderedElement, element);
   });
+}
+
+function annotateSankeyElements(container: HTMLElement, elements: DiagramElement[]): void {
+  const renderedNodes = Array.from(container.querySelectorAll<RenderedDiagramElement>(".nodes .node"));
+  const renderedLabels = Array.from(container.querySelectorAll<RenderedDiagramElement>(".node-labels text"));
+
+  elements.forEach((element, index) => {
+    annotateSankeyRenderedElement(renderedNodes[index], element);
+    annotateSankeyRenderedElement(renderedLabels[index], element);
+  });
+}
+
+function annotateSankeyRenderedElement(
+  renderedElement: RenderedDiagramElement | undefined,
+  element: DiagramElement
+): void {
+  if (renderedElement !== undefined) {
+    setDiagramElementDataset(renderedElement, element);
+  }
 }
 
 function annotateFlowchartConnectors(container: HTMLElement, diagram: ResolvedDiagram): void {

--- a/packages/web-player/src/styles/components/diagram-player.css
+++ b/packages/web-player/src/styles/components/diagram-player.css
@@ -47,6 +47,31 @@
   transition: opacity 400ms ease;
 }
 
+.diagram .links .link {
+  mix-blend-mode: normal !important;
+}
+
+.diagram .links .link path {
+  filter:
+    saturate(var(--color-sankey-link-saturation, 1))
+    contrast(var(--color-sankey-link-contrast, 1));
+  stroke-opacity: var(--color-sankey-link-opacity, 0.72);
+}
+
+.diagram .node-labels text {
+  font-size: var(--color-sankey-label-size, 14px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  paint-order: stroke fill;
+  stroke-linejoin: round;
+  stroke-width: var(--color-sankey-label-stroke-width, 4px);
+}
+
+.diagram .node-labels text:not([data-focus-state="focused"]) {
+  fill: var(--color-sankey-label-text);
+  stroke: var(--color-sankey-label-outline);
+}
+
 .diagram .edgeLabel rect,
 .diagram .labelBkg {
   backdrop-filter: blur(2px);
@@ -203,6 +228,10 @@
   opacity: 0.35 !important;
 }
 
+.diagram .node-labels [data-focus-state="dimmed"] {
+  opacity: 0.48 !important;
+}
+
 [data-focus-state="focused"] {
   opacity: 1;
 }
@@ -243,11 +272,15 @@
 }
 
 [data-focus-state="focused"]:is(text, foreignObject, tspan),
-[data-focus-state="focused"] text,
 [data-focus-state="focused"] foreignObject,
 [data-focus-state="focused"] tspan {
   fill: var(--color-node-focus-text);
   opacity: 1;
+}
+
+.diagram .node-labels [data-focus-state="focused"] {
+  fill: var(--color-node-focus-text);
+  stroke: color-mix(in srgb, var(--accent-primary) 16%, var(--color-sankey-label-outline));
 }
 
 [data-focus-state="focused"][data-diagram-element-kind="message"]:is(text, tspan),

--- a/packages/web-player/src/styles/themes/dark.css
+++ b/packages/web-player/src/styles/themes/dark.css
@@ -58,6 +58,13 @@
   --color-node-hover-fill-strong: #2563eb;
   --color-node-hover-stroke: #bfdbfe;
   --color-node-hover-text: #f8fbff;
+  --color-sankey-label-text: #f8fafc;
+  --color-sankey-label-outline: rgb(14 17 22 / 98%);
+  --color-sankey-label-size: 14px;
+  --color-sankey-label-stroke-width: 5.5px;
+  --color-sankey-link-opacity: 0.64;
+  --color-sankey-link-contrast: 1;
+  --color-sankey-link-saturation: 1.02;
   --color-connector-context-opacity: 0.9;
   --color-connector-context-surface: rgb(14 17 22 / 68%);
   --color-overlay-backdrop: rgb(14 17 22 / 58%);

--- a/packages/web-player/src/styles/themes/light.css
+++ b/packages/web-player/src/styles/themes/light.css
@@ -59,6 +59,13 @@
   --color-node-hover-fill-strong: #93c5fd;
   --color-node-hover-stroke: #3b82f6;
   --color-node-hover-text: #0b1220;
+  --color-sankey-label-text: #0f172a;
+  --color-sankey-label-outline: rgb(255 255 255 / 96%);
+  --color-sankey-label-size: 13.5px;
+  --color-sankey-label-stroke-width: 5px;
+  --color-sankey-link-opacity: 0.68;
+  --color-sankey-link-contrast: 1;
+  --color-sankey-link-saturation: 1.02;
   --color-connector-context-opacity: 0.92;
   --color-connector-context-surface: rgb(255 255 255 / 78%);
   --color-overlay-backdrop: rgb(250 250 250 / 72%);

--- a/packages/web-player/test/layout.server.test.ts
+++ b/packages/web-player/test/layout.server.test.ts
@@ -29,6 +29,7 @@ describe("+layout.server", () => {
       "checkout-payment-flow",
       "flowchart-addressability",
       "payments-platform-overview",
+      "sankey-ops-review",
       "sequence-order-sequence"
     ]);
     expect(result.collection.skipped).toHaveLength(0);
@@ -46,6 +47,7 @@ describe("+layout.server", () => {
       "Payment Flow",
       "Flowchart Addressability",
       "Payments Platform Overview",
+      "Interview Offers Pipeline",
       "Order Sequence"
     ]);
     expect(result.collection.skipped).toEqual([]);

--- a/packages/web-player/test/mermaid-diagram.test.ts
+++ b/packages/web-player/test/mermaid-diagram.test.ts
@@ -94,6 +94,20 @@ describe("mermaid diagram helpers", () => {
     expect(source).toBe("sequenceDiagram\n  participant user as User\n  user->>user: Send request");
   });
 
+  it("keeps sankey source unchanged", () => {
+    const source = createRenderableDiagramSource({
+      elements: [
+        { id: "Checkout", kind: "node", label: "Checkout" },
+        { id: "Gateway", kind: "node", label: "Gateway" }
+      ],
+      path: "./sankey.mmd",
+      source: "sankey-beta\nCheckout,Gateway,120",
+      type: "sankey"
+    });
+
+    expect(source).toBe("sankey-beta\nCheckout,Gateway,120");
+  });
+
   it("renders the diagram and tags nodes with stable app-owned hooks", async () => {
     const container = document.createElement("div");
     document.documentElement.style.setProperty("--bg-base", "#101820");
@@ -137,6 +151,44 @@ describe("mermaid diagram helpers", () => {
       maxWidth: "",
       width: "1440"
     });
+  });
+
+  it("annotates sankey nodes and labels in source order", async () => {
+    mermaidRender.mockResolvedValueOnce({
+      svg: [
+        '<svg width="100%" style="max-width: 960px;" viewBox="0 0 960 640">',
+        '<g class="nodes"><g class="node"><rect></rect></g><g class="node"><rect></rect></g></g>',
+        '<g class="node-labels"><text>Checkout</text><text>Gateway</text></g>',
+        "</svg>"
+      ].join("")
+    });
+
+    const container = document.createElement("div");
+
+    await renderMermaidDiagram({
+      container,
+      diagram: {
+        elements: [
+          { id: "Checkout", kind: "node", label: "Checkout" },
+          { id: "Gateway", kind: "node", label: "Gateway" }
+        ],
+        path: "./sankey.mmd",
+        source: "sankey-beta\nCheckout,Gateway,120",
+        type: "sankey"
+      }
+    });
+
+    expect(container.querySelector('.nodes .node[data-diagram-element-id="Checkout"]')).not.toBeNull();
+    expect(container.querySelector('.node-labels text[data-diagram-element-id="Gateway"]')).not.toBeNull();
+    expect(mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sankey: {
+          height: 860,
+          useMaxWidth: false,
+          width: 1560
+        }
+      })
+    );
   });
 
   it("falls back to Mermaid theme defaults when CSS tokens are missing", async () => {


### PR DESCRIPTION
Closes #75

## Summary
- add parser and model support for common Mermaid Sankey diagrams
- generate Sankey fallback tours as overview plus one step per unique node in first-seen order
- add authored Sankey example, markdown example, docs, tests, and smoke coverage
- improve Sankey player rendering, focus behavior, and Light/Dark readability

## Validation
- `bun run allchecks:ai`