### PR TITLE
[codex] Class diagram support

### DIFF
--- a/.codex/skills/caveman/SKILL.md
+++ b/.codex/skills/caveman/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by speaking like
+  caveman while keeping full technical accuracy. Supports intensity levels:
+  lite, full (default), ultra, wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman",
+  "less tokens", "be brief", or invokes /caveman. Also auto-triggers when
+  token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop filler, hedging, pleasantries. Fragments OK. Preserve user's dominant language. Keep technical terms, code, API names, CLI commands, commit keywords, and exact error strings verbatim.
+
+No self-reference. Never name or announce the style. Output caveman-only unless user explicitly asks otherwise.
+
+## Auto-Clarity
+
+Drop caveman when security warnings, irreversible confirmations, multi-step sequences, or ambiguity need clarity. Resume after clear part done.
+

--- a/.codex/skills/ponytail/SKILL.md
+++ b/.codex/skills/ponytail/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
+  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
+  "minimal solution", "yagni", "do less", or "shortest path", and whenever
+  they complain about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies.
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. Does this need to exist at all? Speculative need = skip it, say so in one line.
+2. Already in this codebase? Reuse it.
+3. Stdlib does it? Use it.
+4. Native platform feature covers it? Use that.
+5. Already-installed dependency solves it? Use it.
+6. Can it be one line? One line.
+7. Only then: minimum code that works.
+
+Bug fix = root cause, not symptom. Grep every caller of the function you're about
+to touch. Fix once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions.
+- No boilerplate, no scaffolding for later.
+- Deletion over addition.
+- Fewest files possible.
+- Complex request? Ship the lazy version and question it in same response.
+- Mark deliberate simplifications with a `ponytail:` comment.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -24,6 +24,8 @@ Load on demand:
 
 ## Communication
 - Use the `caveman` skill by default for all Codex responses in this repo.
+- Use the `ponytail` skill by default when writing or changing code in this repo.
+- Use `graphify` first for codebase questions, architecture lookups, and file-relationship questions when the local graph exists or can be queried.
 - Stay in Caveman mode unless the user explicitly asks for normal mode or the message needs clearer phrasing for safety, irreversible actions, or multi-step instructions.
 
 ## Boundaries

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ The public example library is intentionally minimal and canonical.
 
 Visible public set:
 
+- `class-diagram/dom-injection-api.*` for a class diagram example that mixes extension injection, scraping, API transport, inheritance, composition, statics, and unsafe fields
 - `flowchart/checkout-payment-flow.*` for a small authored flowchart
 - `flowchart/flowchart-addressability.*` for a flowchart example with common shapes, bare endpoints, and a tooltip annotation
 - `flowchart/payments-platform-overview.*` for a large authored interactive demo

--- a/examples/class-diagram/dom-injection-api.md
+++ b/examples/class-diagram/dom-injection-api.md
@@ -1,0 +1,121 @@
+# Browser Extension Data Pipeline
+
+This example shows a browser extension that injects UI into a page, reads visible
+content from the DOM, and posts structured data to an API.
+
+```mermaid
+classDiagram
+
+class BrowserExtension {
+  +String id
+  +String version
+  +Boot()
+  +registerContentScript()
+}
+
+class ContentScriptRunner {
+  -Document document
+  -Window window
+  -Boolean unsafeDomAccess
+  +inject()
+  +extractPageData()
+  +sendToBackground(payload)
+}
+
+class DomInjector {
+  +String selector
+  +Boolean useShadowDom
+  +injectStyles()
+  +injectWidget()
+  +removeWidget()
+}
+
+class PageScraper {
+  +String pageUrl
+  +String pageTitle
+  +readVisibleText() String
+  +readUnsafeDomSnapshot() String
+}
+
+class ApiClient {
+  -String baseUrl
+  -String authToken
+  +String DEFAULT_TIMEOUT_MS$
+  +postPageData(payload)
+  +getConfig()
+}
+
+class RequestQueue {
+  -Number maxRetries
+  -QueuedRequest[] pending
+  +enqueue(request)
+  +flush()
+}
+
+class QueuedRequest {
+  +String requestId
+  +Object payload
+  +Date createdAt
+  +send()
+}
+
+class PageData {
+  +String url
+  +String title
+  +String[] headings
+  +String[] links
+  +String rawHtml
+}
+
+class Logger {
+  <<interface>>
+  +info(message)
+  +warn(message)
+  +error(message)
+}
+
+class ConsoleLogger {
+  +info(message)
+  +warn(message)
+  +error(message)
+}
+
+class PermissionGate {
+  +Boolean canReadPage
+  +Boolean canCallApi
+  +assertPermission(permission)
+}
+
+class StorageAdapter {
+  <<abstract>>
+  +save(key, value)
+  +load(key)
+  +remove(key)
+}
+
+class LocalStorageAdapter {
+  +save(key, value)
+  +load(key)
+  +remove(key)
+}
+
+BrowserExtension *-- ContentScriptRunner : owns
+BrowserExtension *-- ApiClient : owns
+BrowserExtension *-- RequestQueue : owns
+BrowserExtension *-- PermissionGate : owns
+
+ContentScriptRunner *-- DomInjector : composes
+ContentScriptRunner *-- PageScraper : composes
+ContentScriptRunner o-- PageData : produces
+
+PageScraper *-- PageData : builds
+PageScraper ..> Logger : uses
+PageScraper ..> StorageAdapter : caches
+
+ApiClient *-- QueuedRequest : queues
+ApiClient ..> Logger : uses
+ApiClient ..> PermissionGate : checks
+
+ConsoleLogger ..|> Logger
+LocalStorageAdapter --|> StorageAdapter
+```

--- a/examples/class-diagram/dom-injection-api.tour.yaml
+++ b/examples/class-diagram/dom-injection-api.tour.yaml
@@ -1,0 +1,35 @@
+version: 1
+title: Browser Extension Data Pipeline
+diagram: ./dom-injection-api.md#browser-extension-data-pipeline
+
+steps:
+  - focus:
+      - BrowserExtension
+      - ContentScriptRunner
+    text: >
+      {{BrowserExtension}} owns the orchestration while {{ContentScriptRunner}} is the
+      injected worker that bridges the page and the extension.
+
+  - focus:
+      - DomInjector
+      - PageScraper
+      - PageData
+    text: >
+      {{DomInjector}} mounts UI into the page, {{PageScraper}} reads the visible
+      content, and {{PageData}} is the shaped payload they pass around.
+
+  - focus:
+      - ApiClient
+      - RequestQueue
+      - QueuedRequest
+    text: >
+      {{ApiClient}} sends the collected data, with {{RequestQueue}} buffering
+      {{QueuedRequest}} items before each upload.
+
+  - focus:
+      - PermissionGate
+      - StorageAdapter
+      - LocalStorageAdapter
+    text: >
+      {{PermissionGate}} guards access, and the storage abstraction keeps cached
+      state separate from browser-specific persistence.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export interface DiagramTour {
   steps: TourStep[];
 }
 
-export type DiagramType = "flowchart" | "sequence" | "sankey";
+export type DiagramType = "flowchart" | "sequence" | "sankey" | "classDiagram";
 
 export type DiagramElementKind = "node" | "participant" | "message";
 

--- a/packages/parser/src/class-diagram-model.ts
+++ b/packages/parser/src/class-diagram-model.ts
@@ -5,7 +5,7 @@ import { type TourContext } from "./tour-context.js";
 
 const CLASS_DIAGRAM_CLASS_PATTERN = /^\s*class\s+([A-Za-z][A-Za-z0-9_]*)\b/u;
 const CLASS_DIAGRAM_MEMBER_PATTERN =
-  /^\s*([+#~-])?\s*(?:(?:[\w$][\w$.<>\[\]]*\s+)+)?([\w$][\w$]*)\s*(\([^)]*\))?\s*(?::\s*(.+))?\s*$/u;
+  /^\s*([+#~-])?\s*(?:(?:[\w$][\w$.<>]*\s+)+)?([\w$][\w$]*)\s*(\([^)]*\))?\s*(?::\s*(.+))?\s*$/u;
 
 type ClassDiagramElementDraft = {
   id: string;
@@ -26,36 +26,91 @@ function extractClassDiagramElements(source: string): DiagramElement[] {
   let inClassBody = false;
 
   for (const line of source.split("\n")) {
-    const classMatch = line.match(CLASS_DIAGRAM_CLASS_PATTERN);
-
-    if (classMatch !== null) {
-      currentClassId = classMatch[1]!;
-      registerClassDiagramElement(elements, {
-        id: currentClassId,
-        label: currentClassId
-      });
-      inClassBody = line.includes("{") && !line.includes("}");
-      continue;
-    }
-
-    if (!inClassBody || currentClassId === null) {
-      continue;
-    }
-
-    if (line.includes("}")) {
-      inClassBody = false;
-      currentClassId = null;
-      continue;
-    }
-
-    const member = readClassDiagramMember(currentClassId, line);
-
-    if (member !== null) {
-      registerClassDiagramElement(elements, member);
-    }
+    ({ currentClassId, inClassBody } = readClassDiagramLine({
+      currentClassId,
+      elements,
+      inClassBody,
+      line
+    }));
   }
 
   return Array.from(elements.values());
+}
+
+function readClassDiagramLine(input: {
+  currentClassId: string | null;
+  elements: Map<string, DiagramElement>;
+  inClassBody: boolean;
+  line: string;
+}): {
+  currentClassId: string | null;
+  inClassBody: boolean;
+} {
+  const classMatch = input.line.match(CLASS_DIAGRAM_CLASS_PATTERN);
+
+  if (classMatch !== null) {
+    return registerClassLine(input, classMatch[1]!);
+  }
+
+  if (canReadClassBodyLine(input)) {
+    return registerClassBodyLine(input);
+  }
+
+  return input;
+}
+
+function canReadClassBodyLine(input: {
+  currentClassId: string | null;
+  inClassBody: boolean;
+}): boolean {
+  return input.inClassBody && input.currentClassId !== null;
+}
+
+function registerClassLine(
+  input: {
+    currentClassId: string | null;
+    elements: Map<string, DiagramElement>;
+    inClassBody: boolean;
+    line: string;
+  },
+  classId: string
+): {
+  currentClassId: string | null;
+  inClassBody: boolean;
+} {
+  registerClassDiagramElement(input.elements, { id: classId, label: classId });
+
+  return {
+    currentClassId: classId,
+    inClassBody: input.line.includes("{") && !input.line.includes("}")
+  };
+}
+
+function registerClassBodyLine(
+  input: {
+    currentClassId: string | null;
+    elements: Map<string, DiagramElement>;
+    inClassBody: boolean;
+    line: string;
+  }
+): {
+  currentClassId: string | null;
+  inClassBody: boolean;
+} {
+  if (input.line.includes("}")) {
+    return {
+      currentClassId: null,
+      inClassBody: false
+    };
+  }
+
+  const member = readClassDiagramMember(input.currentClassId as string, input.line);
+
+  if (member !== null) {
+    registerClassDiagramElement(input.elements, member);
+  }
+
+  return input;
 }
 
 function readClassDiagramMember(classId: string, line: string): ClassDiagramElementDraft | null {
@@ -65,20 +120,14 @@ function readClassDiagramMember(classId: string, line: string): ClassDiagramElem
     return null;
   }
 
-  const memberName = readClassDiagramMemberName(match);
-
-  if (memberName.length === 0) {
-    return null;
-  }
-
   return {
-    id: `${classId}.${memberName}`,
+    id: `${classId}.${readClassDiagramMemberName(match)}`,
     label: line.trim()
   };
 }
 
 function readClassDiagramMemberName(match: RegExpMatchArray): string {
-  return (match[2] ?? "").trim();
+  return match[2].trim();
 }
 
 function registerClassDiagramElement(

--- a/packages/parser/src/class-diagram-model.ts
+++ b/packages/parser/src/class-diagram-model.ts
@@ -1,0 +1,97 @@
+import type { DiagramElement } from "@diagram-tour/core";
+
+import type { DiagramModel } from "./parser-contracts.js";
+import { type TourContext } from "./tour-context.js";
+
+const CLASS_DIAGRAM_CLASS_PATTERN = /^\s*class\s+([A-Za-z][A-Za-z0-9_]*)\b/u;
+const CLASS_DIAGRAM_MEMBER_PATTERN =
+  /^\s*([+#~-])?\s*(?:(?:[\w$][\w$.<>\[\]]*\s+)+)?([\w$][\w$]*)\s*(\([^)]*\))?\s*(?::\s*(.+))?\s*$/u;
+
+type ClassDiagramElementDraft = {
+  id: string;
+  label: string;
+};
+
+export function createClassDiagramModel(source: string, _context: TourContext): DiagramModel {
+  return {
+    elements: extractClassDiagramElements(source),
+    renderSource: source,
+    type: "classDiagram"
+  };
+}
+
+function extractClassDiagramElements(source: string): DiagramElement[] {
+  const elements = new Map<string, DiagramElement>();
+  let currentClassId: string | null = null;
+  let inClassBody = false;
+
+  for (const line of source.split("\n")) {
+    const classMatch = line.match(CLASS_DIAGRAM_CLASS_PATTERN);
+
+    if (classMatch !== null) {
+      currentClassId = classMatch[1]!;
+      registerClassDiagramElement(elements, {
+        id: currentClassId,
+        label: currentClassId
+      });
+      inClassBody = line.includes("{") && !line.includes("}");
+      continue;
+    }
+
+    if (!inClassBody || currentClassId === null) {
+      continue;
+    }
+
+    if (line.includes("}")) {
+      inClassBody = false;
+      currentClassId = null;
+      continue;
+    }
+
+    const member = readClassDiagramMember(currentClassId, line);
+
+    if (member !== null) {
+      registerClassDiagramElement(elements, member);
+    }
+  }
+
+  return Array.from(elements.values());
+}
+
+function readClassDiagramMember(classId: string, line: string): ClassDiagramElementDraft | null {
+  const match = line.match(CLASS_DIAGRAM_MEMBER_PATTERN);
+
+  if (match === null) {
+    return null;
+  }
+
+  const memberName = readClassDiagramMemberName(match);
+
+  if (memberName.length === 0) {
+    return null;
+  }
+
+  return {
+    id: `${classId}.${memberName}`,
+    label: line.trim()
+  };
+}
+
+function readClassDiagramMemberName(match: RegExpMatchArray): string {
+  return (match[2] ?? "").trim();
+}
+
+function registerClassDiagramElement(
+  elements: Map<string, DiagramElement>,
+  draft: ClassDiagramElementDraft
+): void {
+  if (elements.has(draft.id)) {
+    return;
+  }
+
+  elements.set(draft.id, {
+    id: draft.id,
+    kind: "node",
+    label: draft.label
+  });
+}

--- a/packages/parser/src/diagram-model.ts
+++ b/packages/parser/src/diagram-model.ts
@@ -7,6 +7,7 @@ import type {
 } from "@diagram-tour/core";
 
 import type { DiagramModel } from "./parser-contracts.js";
+import { createClassDiagramModel } from "./class-diagram-model.js";
 import { createFlowchartDiagramModel } from "./flowchart-diagram-model.js";
 import { createSankeyDiagramModel } from "./sankey-diagram-model.js";
 import { createSequenceDiagramModel } from "./sequence-diagram-model.js";
@@ -19,12 +20,17 @@ import {
 
 const NODE_REFERENCE_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
 const SEQUENCE_DIAGRAM_PATTERN = /^\s*sequenceDiagram\b/mu;
+const CLASS_DIAGRAM_PATTERN = /^\s*classDiagram\b/mu;
 const SANKEY_DIAGRAM_PATTERN = /^\s*sankey-beta\b/mu;
 
 type ElementIndex = Map<string, DiagramElement>;
 
 export function createDiagramModel(source: string, context: TourContext): DiagramModel {
   const type = detectDiagramType(source);
+
+  if (type === "classDiagram") {
+    return createClassDiagramModel(source, context);
+  }
 
   if (type === "sequence") {
     return createSequenceDiagramModel(source, context);
@@ -123,6 +129,10 @@ export function readTextReferenceIds(text: string): string[] {
 }
 
 function detectDiagramType(source: string): DiagramType {
+  if (CLASS_DIAGRAM_PATTERN.test(source)) {
+    return "classDiagram";
+  }
+
   if (SEQUENCE_DIAGRAM_PATTERN.test(source)) {
     return "sequence";
   }

--- a/packages/parser/src/diagram-model.ts
+++ b/packages/parser/src/diagram-model.ts
@@ -22,21 +22,24 @@ const NODE_REFERENCE_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
 const SEQUENCE_DIAGRAM_PATTERN = /^\s*sequenceDiagram\b/mu;
 const CLASS_DIAGRAM_PATTERN = /^\s*classDiagram\b/mu;
 const SANKEY_DIAGRAM_PATTERN = /^\s*sankey-beta\b/mu;
+const DIAGRAM_MODEL_FACTORIES = {
+  classDiagram: createClassDiagramDiagramModel,
+  flowchart: createFlowchartDiagramModelAdapter,
+  sankey: createSankeyDiagramModelAdapter,
+  sequence: createSequenceDiagramModel
+} satisfies Record<DiagramType, (source: string, context: TourContext) => DiagramModel>;
+const DIAGRAM_TYPE_PATTERNS = [
+  [CLASS_DIAGRAM_PATTERN, "classDiagram"],
+  [SEQUENCE_DIAGRAM_PATTERN, "sequence"],
+  [SANKEY_DIAGRAM_PATTERN, "sankey"]
+] as const;
 
 type ElementIndex = Map<string, DiagramElement>;
 
 export function createDiagramModel(source: string, context: TourContext): DiagramModel {
   const type = detectDiagramType(source);
 
-  if (type === "classDiagram") {
-    return createClassDiagramModel(source, context);
-  }
-
-  if (type === "sequence") {
-    return createSequenceDiagramModel(source, context);
-  }
-
-  return type === "sankey" ? createSankeyDiagramModel(source) : createFlowchartDiagramModel(source);
+  return DIAGRAM_MODEL_FACTORIES[type](source, context);
 }
 
 export function resolveLoadedTour(input: {
@@ -129,15 +132,19 @@ export function readTextReferenceIds(text: string): string[] {
 }
 
 function detectDiagramType(source: string): DiagramType {
-  if (CLASS_DIAGRAM_PATTERN.test(source)) {
-    return "classDiagram";
-  }
+  return DIAGRAM_TYPE_PATTERNS.find(([pattern]) => pattern.test(source))?.[1] ?? "flowchart";
+}
 
-  if (SEQUENCE_DIAGRAM_PATTERN.test(source)) {
-    return "sequence";
-  }
+function createClassDiagramDiagramModel(source: string, context: TourContext): DiagramModel {
+  return createClassDiagramModel(source, context);
+}
 
-  return SANKEY_DIAGRAM_PATTERN.test(source) ? "sankey" : "flowchart";
+function createFlowchartDiagramModelAdapter(source: string): DiagramModel {
+  return createFlowchartDiagramModel(source);
+}
+
+function createSankeyDiagramModelAdapter(source: string): DiagramModel {
+  return createSankeyDiagramModel(source);
 }
 
 function resolveLoadedTourSteps(

--- a/packages/parser/test/load-resolved-tour.test.ts
+++ b/packages/parser/test/load-resolved-tour.test.ts
@@ -153,6 +153,56 @@ describe("@diagram-tour/parser loadResolvedTour", () => {
     });
   });
 
+  it("loads a valid class diagram tour with class and member references", async () => {
+    const tourPath = await createTempTour({
+      mermaid: [
+        "classDiagram",
+        "  class Animal {",
+        "    +String name",
+        "    +void speak()",
+        "  }",
+        "  class Duck {",
+        "    +void quack()",
+        "  }",
+        "  Animal <|-- Duck"
+      ].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Class Tour",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Animal",
+        "      - Animal.name",
+        "    text: >",
+        "      {{Animal}} exposes {{Animal.name}}."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      diagram: {
+        elements: [
+          { id: "Animal", kind: "node", label: "Animal" },
+          { id: "Animal.name", kind: "node", label: "+String name" },
+          { id: "Animal.speak", kind: "node", label: "+void speak()" },
+          { id: "Duck", kind: "node", label: "Duck" },
+          { id: "Duck.quack", kind: "node", label: "+void quack()" }
+        ],
+        type: "classDiagram"
+      },
+      steps: [
+        {
+          focus: [
+            { id: "Animal", kind: "node", label: "Animal" },
+            { id: "Animal.name", kind: "node", label: "+String name" }
+          ],
+          text: "Animal exposes +String name.\n"
+        }
+      ]
+    });
+  });
+
   it("fails when the tour version is unsupported", async () => {
     const tourPath = await createTempTour({
       mermaid: "flowchart LR\n  api_gateway[API Gateway]",

--- a/packages/parser/test/load-resolved-tour.test.ts
+++ b/packages/parser/test/load-resolved-tour.test.ts
@@ -203,6 +203,41 @@ describe("@diagram-tour/parser loadResolvedTour", () => {
     });
   });
 
+  it("deduplicates repeated class and member declarations in class diagrams", async () => {
+    const tourPath = await createTempTour({
+      mermaid: [
+        "classDiagram",
+        "  class Animal {",
+        "    +String name",
+        "  }",
+        "  class Animal {",
+        "    +String name",
+        "  }"
+      ].join("\n"),
+      yaml: [
+        "version: 1",
+        "title: Duplicate Class Tour",
+        "diagram: ./diagram.mmd",
+        "",
+        "steps:",
+        "  - focus:",
+        "      - Animal",
+        "    text: >",
+        "      {{Animal}} remains unique."
+      ].join("\n")
+    });
+
+    await expect(loadResolvedTour(tourPath)).resolves.toMatchObject({
+      diagram: {
+        elements: [
+          { id: "Animal", kind: "node", label: "Animal" },
+          { id: "Animal.name", kind: "node", label: "+String name" }
+        ],
+        type: "classDiagram"
+      }
+    });
+  });
+
   it("fails when the tour version is unsupported", async () => {
     const tourPath = await createTempTour({
       mermaid: "flowchart LR\n  api_gateway[API Gateway]",

--- a/packages/parser/test/parser-test-support.ts
+++ b/packages/parser/test/parser-test-support.ts
@@ -17,6 +17,10 @@ export const FIXTURE_TOUR_PATH = resolve(
 export const DISCOVERY_FIXTURE_ROOT = resolve(TEST_DIR, "./fixtures/discovery");
 export const INVALID_ONLY_FIXTURE_ROOT = resolve(TEST_DIR, "./fixtures/invalid-only");
 export const EXAMPLES_ROOT = resolve(TEST_DIR, "../../../examples");
+export const CLASS_DIAGRAM_FIXTURE_TOUR_PATH = resolve(
+  TEST_DIR,
+  "../../web-player/test/fixtures/class-diagram.tour.yaml"
+);
 
 export function restoreParserTestState(): void {
   vi.restoreAllMocks();

--- a/packages/parser/test/tour-collection.test.ts
+++ b/packages/parser/test/tour-collection.test.ts
@@ -6,6 +6,7 @@ import { loadResolvedTourCollection, validateDiscoveredTours } from "../src/inde
 import {
   DISCOVERY_FIXTURE_ROOT,
   EXAMPLES_ROOT,
+  CLASS_DIAGRAM_FIXTURE_TOUR_PATH,
   FIXTURE_TOUR_PATH,
   INVALID_ONLY_FIXTURE_ROOT,
   createTempDiagramDirectory,
@@ -130,6 +131,64 @@ describe("@diagram-tour/parser tour collection", () => {
       "Inbound Intake feeds the branching Decision that controls the rest of the flow.\n",
       "This path shows common flowchart shapes, including bare endpoints like archive and metadata-shaped nodes like Done.\n",
       "The flowchart stays fully navigable in the browser while the diagram source keeps its original Mermaid annotations.\n"
+    ]);
+  });
+
+  it("builds generated fallback steps from a raw class diagram file target", async () => {
+    const classRoot = await createTempDiagramDirectory({
+      "models/animal-hierarchy.mmd": [
+        "classDiagram",
+        "  class Animal {",
+        "    +String name",
+        "    +void speak()",
+        "  }",
+        "  class Duck {",
+        "    +void quack()",
+        "  }",
+        "  Animal <|-- Duck"
+      ].join("\n")
+    });
+
+    const collection = await loadResolvedTourCollection(resolve(classRoot, "./models/animal-hierarchy.mmd"));
+    const entry = readCollectionEntryAt(collection, 0);
+
+    expect(entry.tour.diagram.type).toBe("classDiagram");
+    expect(entry.tour.diagram.elements.map((element) => element.id)).toEqual([
+      "Animal",
+      "Animal.name",
+      "Animal.speak",
+      "Duck",
+      "Duck.quack"
+    ]);
+    expect(entry.tour.steps.map((step) => step.text)).toEqual([
+      "Overview of Animal Hierarchy.",
+      "Focus on Animal.",
+      "Focus on +String name.",
+      "Focus on +void speak().",
+      "Focus on Duck.",
+      "Focus on +void quack()."
+    ]);
+  });
+
+  it("loads the real class diagram fixture pair from the web-player fixtures", async () => {
+    const collection = await loadResolvedTourCollection(
+      CLASS_DIAGRAM_FIXTURE_TOUR_PATH
+    );
+
+    expect(collection.entries).toHaveLength(1);
+    expect(collection.entries[0]).toMatchObject({
+      slug: "class-diagram",
+      title: "Class Tour",
+      tour: {
+        diagram: {
+          type: "classDiagram"
+        },
+        sourceKind: "authored"
+      }
+    });
+    expect(collection.entries[0]?.tour.steps[0]?.focus.map((element) => element.id)).toEqual([
+      "Animal",
+      "Animal.name"
     ]);
   });
 
@@ -373,6 +432,7 @@ describe("@diagram-tour/parser tour collection", () => {
     const collection = await loadResolvedTourCollection(EXAMPLES_ROOT);
 
     expect(collection.entries.map((entry) => entry.slug)).toEqual([
+      "class-diagram/dom-injection-api",
       "flowchart/checkout-payment-flow",
       "flowchart/flowchart-addressability",
       "flowchart/payments-platform-overview",

--- a/packages/web-player/src/lib/mermaid-diagram.ts
+++ b/packages/web-player/src/lib/mermaid-diagram.ts
@@ -30,6 +30,15 @@ type SvgPointLike = { x: number; y: number };
 const MESSAGE_MARKER_ATTRIBUTES = ["marker-start", "marker-mid", "marker-end"] as const;
 const FLOWCHART_MARKER_ATTRIBUTES = ["marker-start", "marker-end"] as const;
 const FLOWCHART_CONNECTOR_SELECTOR = ".edgePath path, .flowchart-link";
+const DIAGRAM_ANNOTATORS = {
+  classDiagram: annotateClassElements,
+  flowchart: annotateFlowchartElements,
+  sankey: annotateSankeyElements,
+  sequence: annotateSequenceElements
+} satisfies Record<
+  ResolvedDiagram["type"],
+  (container: HTMLElement, elements: DiagramElement[]) => void
+>;
 const MERMAID_THEME_DEFAULTS = {
   background: "#0e1116",
   fontFamily: MERMAID_FONT_STACK,
@@ -214,25 +223,7 @@ async function renderDiagramSource(input: {
 }
 
 function annotateRenderedElements(container: HTMLElement, diagram: ResolvedDiagram): void {
-  if (diagram.type === "classDiagram") {
-    annotateClassElements(container, diagram.elements);
-
-    return;
-  }
-
-  if (diagram.type === "sequence") {
-    annotateSequenceElements(container, diagram.elements);
-
-    return;
-  }
-
-  if (diagram.type === "sankey") {
-    annotateSankeyElements(container, diagram.elements);
-
-    return;
-  }
-
-  annotateFlowchartElements(container, diagram.elements);
+  DIAGRAM_ANNOTATORS[diagram.type](container, diagram.elements);
 }
 
 function annotateFlowchartElements(container: HTMLElement, elements: DiagramElement[]): void {

--- a/packages/web-player/src/lib/mermaid-diagram.ts
+++ b/packages/web-player/src/lib/mermaid-diagram.ts
@@ -214,6 +214,12 @@ async function renderDiagramSource(input: {
 }
 
 function annotateRenderedElements(container: HTMLElement, diagram: ResolvedDiagram): void {
+  if (diagram.type === "classDiagram") {
+    annotateClassElements(container, diagram.elements);
+
+    return;
+  }
+
   if (diagram.type === "sequence") {
     annotateSequenceElements(container, diagram.elements);
 
@@ -239,6 +245,73 @@ function annotateFlowchartElements(container: HTMLElement, elements: DiagramElem
 
     setDiagramElementDataset(renderedElement, element);
   });
+}
+
+function annotateClassElements(container: HTMLElement, elements: DiagramElement[]): void {
+  const renderedClassNodes = Array.from(
+    container.querySelectorAll<RenderedDiagramElement>("svg.classDiagram g.node.default")
+  );
+  const classElements = elements.filter(isClassNodeElement);
+  const memberElementGroups = groupClassMemberElements(elements);
+
+  renderedClassNodes.forEach((renderedClassNode) => {
+    const classLabel = readClassNodeLabel(renderedClassNode);
+    const classElement = classElements.find((candidate) => candidate.label === classLabel);
+
+    if (classElement === undefined) {
+      return;
+    }
+
+    setDiagramElementDataset(renderedClassNode, classElement);
+    annotateClassNodeMembers(renderedClassNode, memberElementGroups.get(classElement.id) ?? []);
+  });
+}
+
+function annotateClassNodeMembers(
+  renderedClassNode: RenderedDiagramElement,
+  memberElements: DiagramElement[]
+): void {
+  const renderedMemberLabels = Array.from(
+    renderedClassNode.querySelectorAll<RenderedDiagramElement>(".members-group .label, .methods-group .label")
+  );
+
+  memberElements.forEach((memberElement) => {
+    const renderedMemberLabel = renderedMemberLabels.find(
+      (candidate) => normalizeTextContent(candidate) === memberElement.label
+    );
+
+    if (renderedMemberLabel === undefined) {
+      return;
+    }
+
+    setDiagramElementDataset(renderedMemberLabel, memberElement);
+  });
+}
+
+function groupClassMemberElements(elements: DiagramElement[]): Map<string, DiagramElement[]> {
+  const groups = new Map<string, DiagramElement[]>();
+
+  elements.filter(isClassMemberElement).forEach((element) => {
+    const classId = readClassMemberClassId(element.id);
+    const group = groups.get(classId) ?? [];
+
+    group.push(element);
+    groups.set(classId, group);
+  });
+
+  return groups;
+}
+
+function isClassNodeElement(element: DiagramElement): boolean {
+  return !isClassMemberElement(element);
+}
+
+function isClassMemberElement(element: DiagramElement): boolean {
+  return element.id.includes(".");
+}
+
+function readClassMemberClassId(elementId: string): string {
+  return elementId.slice(0, elementId.lastIndexOf("."));
 }
 
 function annotateSankeyElements(container: HTMLElement, elements: DiagramElement[]): void {
@@ -928,7 +1001,7 @@ function findSequenceMessageTextIndex(
   return -1;
 }
 
-function normalizeTextContent(element: RenderedDiagramElement): string {
+function normalizeTextContent(element: Element): string {
   return (element.textContent || "").replace(/\s+/gu, " ").trim();
 }
 
@@ -1008,6 +1081,10 @@ function createClassStatement(nodeId: string): string {
 
 function createNodeClass(nodeId: string): string {
   return `${APP_NODE_CLASS_PREFIX}${nodeId}`;
+}
+
+function readClassNodeLabel(element: RenderedDiagramElement): string {
+  return normalizeTextContent(element.querySelector(".label-group .label") ?? element);
 }
 
 function readDiagramElementId(element: RenderedDiagramElement): string {

--- a/packages/web-player/test/fixtures/class-diagram.mmd
+++ b/packages/web-player/test/fixtures/class-diagram.mmd
@@ -1,0 +1,9 @@
+classDiagram
+  class Animal {
+    +String name
+    +void speak()
+  }
+  class Duck {
+    +void quack()
+  }
+  Animal <|-- Duck

--- a/packages/web-player/test/fixtures/class-diagram.tour.yaml
+++ b/packages/web-player/test/fixtures/class-diagram.tour.yaml
@@ -1,0 +1,10 @@
+version: 1
+title: Class Tour
+diagram: ./class-diagram.mmd
+
+steps:
+  - focus:
+      - Animal
+      - Animal.name
+    text: >
+      {{Animal}} exposes {{Animal.name}}.

--- a/packages/web-player/test/fixtures/resolved-tour.ts
+++ b/packages/web-player/test/fixtures/resolved-tour.ts
@@ -48,3 +48,39 @@ export const resolvedPaymentFlowTour: ResolvedDiagramTour = {
     }
   ]
 };
+
+export const resolvedClassTour: ResolvedDiagramTour = {
+  sourceKind: "authored",
+  version: 1,
+  title: "Class Tour",
+  diagram: {
+    elements: [
+      { id: "Animal", kind: "node", label: "Animal" },
+      { id: "Animal.name", kind: "node", label: "+String name" },
+      { id: "Animal.speak", kind: "node", label: "+void speak()" },
+      { id: "Duck", kind: "node", label: "Duck" },
+      { id: "Duck.quack", kind: "node", label: "+void quack()" }
+    ],
+    path: "./animal-hierarchy.mmd",
+    source: `classDiagram
+  class Animal {
+    +String name
+    +void speak()
+  }
+  class Duck {
+    +void quack()
+  }
+  Animal <|-- Duck`,
+    type: "classDiagram"
+  },
+  steps: [
+    {
+      index: 1,
+      focus: [
+        { id: "Animal", kind: "node", label: "Animal" },
+        { id: "Animal.name", kind: "node", label: "+String name" }
+      ],
+      text: "Animal exposes +String name."
+    }
+  ]
+};

--- a/packages/web-player/test/layout.server.test.ts
+++ b/packages/web-player/test/layout.server.test.ts
@@ -26,6 +26,7 @@ describe("+layout.server", () => {
     const result = await loadExamplesCollection();
 
     expect(result.collection.entries.map((entry) => entry.slug)).toEqual([
+      "class-diagram/dom-injection-api",
       "flowchart/checkout-payment-flow",
       "flowchart/flowchart-addressability",
       "flowchart/payments-platform-overview",
@@ -44,6 +45,7 @@ describe("+layout.server", () => {
     const result = await loadExamplesCollection();
 
     expect(result.collection.entries.map((entry) => entry.title)).toEqual([
+      "Browser Extension Data Pipeline",
       "Payment Flow",
       "Flowchart Addressability",
       "Payments Platform Overview",

--- a/packages/web-player/test/mermaid-diagram.test.ts
+++ b/packages/web-player/test/mermaid-diagram.test.ts
@@ -189,6 +189,66 @@ describe("mermaid diagram helpers", () => {
     expect(container.querySelector('[data-node-id="Duck"]')).not.toBeNull();
   });
 
+  it("falls back to the class node element when Mermaid omits a label-group wrapper", async () => {
+    mermaidRender.mockResolvedValueOnce({
+      svg: [
+        '<svg class="classDiagram" width="100%" style="max-width: 960px;" viewBox="0 0 960 640">',
+        '<g class="node default" id="classId-Animal-0">Animal</g>',
+        "</svg>"
+      ].join("")
+    });
+
+    const container = document.createElement("div");
+
+    await renderMermaidDiagram({
+      container,
+      diagram: {
+        elements: [{ id: "Animal", kind: "node", label: "Animal" }],
+        path: "./class-diagram.mmd",
+        source: "classDiagram\n  class Animal",
+        type: "classDiagram"
+      }
+    });
+
+    expect(container.querySelector('[data-node-id="Animal"]')).not.toBeNull();
+    expect(container.querySelector('[data-node-label="Animal"]')).not.toBeNull();
+  });
+
+  it("skips unmatched class nodes and member labels in class diagrams", async () => {
+    mermaidRender.mockResolvedValueOnce({
+      svg: [
+        '<svg class="classDiagram" width="100%" style="max-width: 960px;" viewBox="0 0 960 640">',
+        '<g class="node default" id="classId-Ghost-0">',
+        '<g class="label-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>Ghost</p></span></div></foreignObject></g></g>',
+        "</g>",
+        '<g class="node default" id="classId-Animal-1">',
+        '<g class="label-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>Animal</p></span></div></foreignObject></g></g>',
+        '<g class="members-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>+String fur</p></span></div></foreignObject></g></g>',
+        "</g>",
+        "</svg>"
+      ].join("")
+    });
+
+    const container = document.createElement("div");
+
+    await renderMermaidDiagram({
+      container,
+      diagram: {
+        elements: [
+          { id: "Animal", kind: "node", label: "Animal" },
+          { id: "Animal.name", kind: "node", label: "+String name" }
+        ],
+        path: "./class-diagram.mmd",
+        source: "classDiagram\n  class Animal {\n    +String name\n  }",
+        type: "classDiagram"
+      }
+    });
+
+    expect(container.querySelector('[data-node-id="Ghost"]')).toBeNull();
+    expect(container.querySelector('[data-node-id="Animal.name"]')).toBeNull();
+    expect(container.querySelector('[data-node-id="Animal"]')).not.toBeNull();
+  });
+
   it("annotates sankey nodes and labels in source order", async () => {
     mermaidRender.mockResolvedValueOnce({
       svg: [

--- a/packages/web-player/test/mermaid-diagram.test.ts
+++ b/packages/web-player/test/mermaid-diagram.test.ts
@@ -7,7 +7,7 @@ import {
   renderMermaidDiagram
 } from "../src/lib/mermaid-diagram";
 import { createFocusGroup } from "../src/lib/focus-group";
-import { resolvedPaymentFlowTour } from "./fixtures/resolved-tour";
+import { resolvedClassTour, resolvedPaymentFlowTour } from "./fixtures/resolved-tour";
 
 const { mermaidInitialize, mermaidRender } = vi.hoisted(() => ({
   mermaidInitialize: vi.fn(),
@@ -94,6 +94,12 @@ describe("mermaid diagram helpers", () => {
     expect(source).toBe("sequenceDiagram\n  participant user as User\n  user->>user: Send request");
   });
 
+  it("adds app-owned node classes to class diagram source", () => {
+    const source = createRenderableDiagramSource(resolvedClassTour.diagram);
+
+    expect(source).toBe(resolvedClassTour.diagram.source);
+  });
+
   it("keeps sankey source unchanged", () => {
     const source = createRenderableDiagramSource({
       elements: [
@@ -151,6 +157,36 @@ describe("mermaid diagram helpers", () => {
       maxWidth: "",
       width: "1440"
     });
+  });
+
+  it("renders and tags class diagram nodes", async () => {
+    mermaidRender.mockResolvedValueOnce({
+      svg: [
+        '<svg class="classDiagram" width="100%" style="max-width: 960px;" viewBox="0 0 960 640">',
+        '<g class="node default" id="classId-Animal-0">',
+        '<g class="label-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>Animal</p></span></div></foreignObject></g></g>',
+        '<g class="members-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>+String name</p></span></div></foreignObject></g></g>',
+        '<g class="methods-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>+void speak()</p></span></div></foreignObject></g></g>',
+        "</g>",
+        '<g class="node default" id="classId-Duck-1">',
+        '<g class="label-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>Duck</p></span></div></foreignObject></g></g>',
+        '<g class="methods-group text"><g class="label"><foreignObject><div><span class="nodeLabel markdown-node-label"><p>+void quack()</p></span></div></foreignObject></g></g>',
+        "</g>",
+        "</svg>"
+      ].join("")
+    });
+
+    const container = document.createElement("div");
+
+    await renderMermaidDiagram({
+      container,
+      diagram: resolvedClassTour.diagram
+    });
+
+    expect(container.querySelector('[data-node-id="Animal"]')).not.toBeNull();
+    expect(container.querySelector('[data-node-id="Animal.name"]')).not.toBeNull();
+    expect(container.querySelector('[data-node-label="Animal"]')).not.toBeNull();
+    expect(container.querySelector('[data-node-id="Duck"]')).not.toBeNull();
   });
 
   it("annotates sankey nodes and labels in source order", async () => {


### PR DESCRIPTION
## What changed
- Added `classDiagram` support through parser and web-player paths.
- Added class-diagram example tour fixtures and tests.
- Fixed the class-diagram rendering and highlight flow for the teleprompter path.

## Validation
- `bun run test:unit`
- `bun run smoke`
- `bun run lint`

Closes #58
